### PR TITLE
Modernize code to Python 3.6+

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,3 +10,5 @@ exclude *.md
 exclude *.yml
 include LICENSE
 exclude tox.ini
+
+include README.md

--- a/fpdf/fonts.py
+++ b/fpdf/fonts.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 # Fonts:
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # ****************************************************************************
 # * Software: FPDF for python                                                *
 # * License:  LGPL v3.0                                                      *

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -112,7 +112,7 @@ def load_cache(filename):
         with open(filename, "rb") as fh:
             return pickle.load(fh)
     # File missing, unsupported pickle, etc
-    except (IOError, ValueError):
+    except (OSError, ValueError):
         return None
 
 
@@ -638,7 +638,7 @@ class FPDF:
                     try:
                         with open(unifilename, "wb") as fh:
                             pickle.dump(font_dict, fh)
-                    except IOError as e:
+                    except OSError as e:
                         if e.errno != errno.EACCES:
                             raise  # Not a permission error.
                 del ttf
@@ -1886,7 +1886,7 @@ class FPDF:
                         font_dict["range_interval"] = range_interval
                         font_dict["range"] = range_
                         pickle.dump(font_dict, fh)
-                except IOError as e:
+                except OSError as e:
                     if e.errno != errno.EACCES:
                         raise  # Not a permission error.
 

--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 "HTML Renderer for FPDF.py"
 
 __author__ = "Mariano Reingart <reingart@gmail.com>"

--- a/fpdf/image_parsing.py
+++ b/fpdf/image_parsing.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import zlib
 from io import BytesIO
 from urllib.request import urlopen

--- a/fpdf/template.py
+++ b/fpdf/template.py
@@ -1,5 +1,3 @@
-# -*- coding: iso-8859-1 -*-
-
 "PDF Template Helper for FPDF.py"
 
 __author__ = "Mariano Reingart <reingart@gmail.com>"

--- a/fpdf/util/__init__.py
+++ b/fpdf/util/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 "Utility Functions"
 import locale
 

--- a/fpdf/util/syntax.py
+++ b/fpdf/util/syntax.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """PDF Syntax Helpers
 
 Functions in this module take variable input and produce PDF Syntax features

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def run_test_suite():
 
 def read(path):
     """Read a file's contents."""
-    with open(path, "r") as f:
+    with open(path) as f:
         return f.read()
 
 

--- a/test/end_to_end_legacy/charmap/charmap_test.py
+++ b/test/end_to_end_legacy/charmap/charmap_test.py
@@ -61,7 +61,7 @@ class CharmapTest(unittest.TestCase):
 
                 # Create a PDF with the first 999 charters defined in the font:
                 for counter, character in enumerate(ttf.saveChar, 0):
-                    pdf.write(8, u"%03d) %03x - %c" % (counter, character, character))
+                    pdf.write(8, "%03d) %03x - %c" % (counter, character, character))
                     pdf.ln()
                     if counter >= 999:
                         break

--- a/tutorial/unicode.py
+++ b/tutorial/unicode.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
 
 from fpdf import FPDF
 import sys

--- a/tutorial/unicode.py
+++ b/tutorial/unicode.py
@@ -12,7 +12,7 @@ pdf.add_page()
 pdf.add_font("DejaVu", fname="DejaVuSansCondensed.ttf", uni=True)
 pdf.set_font("DejaVu", size=14)
 
-text = u"""
+text = """
 English: Hello World
 Greek: Γειά σου κόσμος
 Polish: Witaj świecie
@@ -33,15 +33,15 @@ for txt in text.split("\n"):
 #           Kannada, Malayalam, Oriya, Tamil, Telugu, Tibetan
 pdf.add_font("gargi", fname="gargi.ttf", uni=True)
 pdf.set_font("gargi", size=14)
-pdf.write(8, u"Hindi: नमस्ते दुनिया")
+pdf.write(8, "Hindi: नमस्ते दुनिया")
 pdf.ln(20)
 
 # Add a AR PL New Sung Unicode font (uses UTF-8)
 # The Open Source Chinese Font (also supports other east Asian languages)
 pdf.add_font("fireflysung", fname="fireflysung.ttf", uni=True)
 pdf.set_font("fireflysung", size=14)
-pdf.write(8, u"Chinese: 你好世界\n")
-pdf.write(8, u"Japanese: こんにちは世界\n")
+pdf.write(8, "Chinese: 你好世界\n")
+pdf.write(8, "Japanese: こんにちは世界\n")
 pdf.ln(10)
 
 # Add a Alee Unicode font (uses UTF-8)
@@ -49,13 +49,13 @@ pdf.ln(10)
 # and Latin9 (iso8859-15) characters.
 pdf.add_font("eunjin", fname="Eunjin.ttf", uni=True)
 pdf.set_font("eunjin", size=14)
-pdf.write(8, u"Korean: 안녕하세요")
+pdf.write(8, "Korean: 안녕하세요")
 pdf.ln(20)
 
 # Add a Fonts-TLWG (formerly ThaiFonts-Scalable) (uses UTF-8)
 pdf.add_font("waree", fname="Waree.ttf", uni=True)
 pdf.set_font("waree", size=14)
-pdf.write(8, u"Thai: สวัสดีชาวโลก")
+pdf.write(8, "Thai: สวัสดีชาวโลก")
 pdf.ln(20)
 
 # Select a standard font (uses windows-1252)


### PR DESCRIPTION
Remove some redundant code that is covered by defaults in Python 3.

And I had to include `README.md` to `MANIFEST.in`. Without that, `tox` failed with an error, that the file `'./README.md` could not be found. Wondering why nobody else had that problem.