### PR TITLE
Compact some code

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ On [fpdf2](https://github.com/pyfpdf/fpdf2/graphs/contributors):
 - Christopher Frost
 - Abishek Goda
 - xitrushiy
+- Miroslav Šedivý
 
 On the original [PyFPDF](https://github.com/reingart/pyfpdf/graphs/contributors):
 

--- a/fpdf/fonts.py
+++ b/fpdf/fonts.py
@@ -6,7 +6,7 @@ fpdf_charwidths = {}
 
 fpdf_charwidths["courier"] = {}
 
-for i in range(0, 256):
+for i in range(256):
     fpdf_charwidths["courier"][chr(i)] = 600
     fpdf_charwidths["courierB"] = fpdf_charwidths["courier"]
     fpdf_charwidths["courierI"] = fpdf_charwidths["courier"]

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -433,7 +433,6 @@ class FPDF:
         s = s if normalized else self.normalize_text(s)
         cw = self.current_font["cw"]
         w = 0
-        l = len(s)
         if self.unifontsubset:
             for char in s:
                 char = ord(char)
@@ -444,8 +443,7 @@ class FPDF:
                 else:
                     w += 500
         else:
-            for i in range(0, l):
-                w += cw.get(s[i], 0)
+            w += sum(cw.get(char, 0) for char in s)
         if self.font_stretching != 100:
             w = w * self.font_stretching / 100
         return w * self.font_size / 1000
@@ -628,7 +626,7 @@ class FPDF:
                 del ttf
 
             # include numbers in the subset! (if alias present)
-            sbarr = list(range(0, 57 if self.str_alias_nb_pages else 32))
+            sbarr = list(range(57 if self.str_alias_nb_pages else 32))
 
             self.fonts[fontkey] = {
                 "i": len(self.fonts) + 1,
@@ -663,7 +661,7 @@ class FPDF:
                     if self.diffs[i] == diff:
                         d = i
                         break
-                if d == 0:
+                else:
                     d = nb + 1
                     self.diffs[d] = diff
                 self.fonts[fontkey]["diff"] = d
@@ -1575,7 +1573,7 @@ class FPDF:
         self._out("1 0 obj")
         self._out("<</Type /Pages")
         kids = "/Kids ["
-        for i in range(0, nb):
+        for i in range(nb):
             kids += f"{3 + 2 * i} 0 R "
         self._out(kids + "]")
         self._out(f"/Count {nb}")
@@ -1971,9 +1969,7 @@ class FPDF:
                 self._out(f"/DecodeParms <<{info['dp']}>>")
 
             if "trns" in info and isinstance(info["trns"], list):
-                trns = ""
-                for i in range(0, len(info["trns"])):
-                    trns += f"{info['trns'][i]} {info['trns'][i]} "
+                trns = " ".join(f"{x} {x}" for x in info["trns"])
                 self._out(f"/Mask [{trns}]")
 
             if "smask" in info:
@@ -2263,9 +2259,9 @@ class FPDF:
                 raise RuntimeError(f'Char "{char_space}" invalid for I25: ')
 
             # create a wide/narrow-seq (first digit=bars, second digit=spaces)
-            seq = ""
-            for s in range(0, len(bar_char[char_bar])):
-                seq += bar_char[char_bar][s] + bar_char[char_space][s]
+            seq = "".join(
+                f"{cb}{cs}" for cb, cs in zip(bar_char[char_bar], bar_char[char_space])
+            )
 
             for bar, char in enumerate(seq):
                 # set line_width depending on value

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -2257,9 +2257,9 @@ class FPDF:
             char_bar = code[i]
             char_space = code[i + 1]
             # check whether it is a valid digit
-            if char_bar not in bar_char.keys():
+            if char_bar not in bar_char:
                 raise RuntimeError(f'Char "{char_bar}" invalid for I25:')
-            if not char_space in bar_char.keys():
+            if char_space not in bar_char:
                 raise RuntimeError(f'Char "{char_space}" invalid for I25: ')
 
             # create a wide/narrow-seq (first digit=bars, second digit=spaces)

--- a/fpdf/ttfonts.py
+++ b/fpdf/ttfonts.py
@@ -205,7 +205,7 @@ class TTFontFile:
         numRecords = self.read_ushort()
         string_data_offset = name_offset + self.read_ushort()
         names = {1: "", 2: "", 3: "", 4: "", 6: ""}
-        K = list(names.keys())
+        K = list(names)
         nameCount = len(names)
         for _ in range(numRecords):
             platformId = self.read_ushort()

--- a/tutorial/tuto5.py
+++ b/tutorial/tuto5.py
@@ -28,8 +28,8 @@ class PDF(FPDF):
         # Column widths
         w = [40, 35, 40, 45]
         # Header
-        for i in range(0, len(header)):
-            self.cell(w[i], 7, header[i], 1, 0, "C")
+        for width, header_text in zip(w, header):
+            self.cell(width, 7, header_text, 1, 0, "C")
         self.ln()
         # Data
         for row in data:
@@ -51,8 +51,8 @@ class PDF(FPDF):
         self.set_font(style="B")
         # Header
         w = [40, 35, 40, 45]
-        for i in range(0, len(header)):
-            self.cell(w[i], 7, header[i], 1, 0, "C", 1)
+        for width, header_text in zip(w, header):
+            self.cell(width, 7, header_text, 1, 0, "C", 1)
         self.ln()
         # Color and font restoration
         self.set_fill_color(224, 235, 255)


### PR DESCRIPTION
1. access dict.keys() implicitly
2. `range(0, x)` can be written as `range(x)`, simplify some loops and iterate directly over the elements