### PR TITLE
Replace collections.OrderedDict() with dict()

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -17,7 +17,6 @@ The version number is updated here (above and below in variable).
 
 from contextlib import contextmanager
 from datetime import datetime
-from collections import OrderedDict
 from functools import wraps
 from uuid import uuid4
 import errno
@@ -2047,14 +2046,14 @@ class FPDF:
             self._out("endobj")
 
     def _putinfo(self):
-        info_d = OrderedDict()
-        info_d[pdf_name("title")] = enclose_in_parens(getattr(self, "title", None))
-        info_d[pdf_name("subject")] = enclose_in_parens(getattr(self, "subject", None))
-        info_d[pdf_name("author")] = enclose_in_parens(getattr(self, "author", None))
-        info_d[pdf_name("keywords")] = enclose_in_parens(
-            getattr(self, "keywords", None)
-        )
-        info_d[pdf_name("creator")] = enclose_in_parens(getattr(self, "creator", None))
+        info_d = {pdf_name("title"): enclose_in_parens(getattr(self, "title", None)),
+                  pdf_name("subject"): enclose_in_parens(
+                      getattr(self, "subject", None)),
+                  pdf_name("author"): enclose_in_parens(getattr(self, "author", None)),
+                  pdf_name("keywords"): enclose_in_parens(
+                      getattr(self, "keywords", None)
+                  ), pdf_name("creator"): enclose_in_parens(
+                getattr(self, "creator", None))}
 
         if hasattr(self, "creation_date"):
             try:
@@ -2071,9 +2070,8 @@ class FPDF:
         self._out(pdf_d(info_d, open_dict="", close_dict="", has_empty_fields=True))
 
     def _putcatalog(self):
-        catalog_d = OrderedDict()
-        catalog_d[pdf_name("type")] = pdf_name("catalog")
-        catalog_d[pdf_name("pages")] = pdf_ref(1)
+        catalog_d = {pdf_name("type"): pdf_name("catalog"),
+                     pdf_name("pages"): pdf_ref(1)}
 
         zoom_configs = {
             "default": ["/Fit"],  # TODO FIXME

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -2046,14 +2046,13 @@ class FPDF:
             self._out("endobj")
 
     def _putinfo(self):
-        info_d = {pdf_name("title"): enclose_in_parens(getattr(self, "title", None)),
-                  pdf_name("subject"): enclose_in_parens(
-                      getattr(self, "subject", None)),
-                  pdf_name("author"): enclose_in_parens(getattr(self, "author", None)),
-                  pdf_name("keywords"): enclose_in_parens(
-                      getattr(self, "keywords", None)
-                  ), pdf_name("creator"): enclose_in_parens(
-                getattr(self, "creator", None))}
+        info_d = {
+            pdf_name("title"): enclose_in_parens(getattr(self, "title", None)),
+            pdf_name("subject"): enclose_in_parens(getattr(self, "subject", None)),
+            pdf_name("author"): enclose_in_parens(getattr(self, "author", None)),
+            pdf_name("keywords"): enclose_in_parens(getattr(self, "keywords", None)),
+            pdf_name("creator"): enclose_in_parens(getattr(self, "creator", None)),
+        }
 
         if hasattr(self, "creation_date"):
             try:
@@ -2070,8 +2069,10 @@ class FPDF:
         self._out(pdf_d(info_d, open_dict="", close_dict="", has_empty_fields=True))
 
     def _putcatalog(self):
-        catalog_d = {pdf_name("type"): pdf_name("catalog"),
-                     pdf_name("pages"): pdf_ref(1)}
+        catalog_d = {
+            pdf_name("type"): pdf_name("catalog"),
+            pdf_name("pages"): pdf_ref(1),
+        }
 
         zoom_configs = {
             "default": ["/Fit"],  # TODO FIXME

--- a/fpdf/util/syntax.py
+++ b/fpdf/util/syntax.py
@@ -46,10 +46,6 @@ third_obj = {
   pdf_name('Contents'): iobj_ref(4),
 }
 
-`collections.OrderedDict` is used because ultimately to test the accuracy of
-the documents created, order of the fields matters even though it probably
-doesn't in the Adobe Specification.
-
 Some additional notes:
 
 Streams are of the form:
@@ -69,9 +65,7 @@ that string.
 
 As of this writing, I am not sure how length is actually calculated, so this
 remains something to be looked into.
-
 """
-from collections import OrderedDict
 
 
 def create_name(name):
@@ -81,7 +75,7 @@ def create_name(name):
 
 
 def clear_empty_fields(d):
-    return OrderedDict((k, v) for k, v in d.items() if v)
+    return {k: v for k, v in d.items() if v}
 
 
 def create_dictionary_string(
@@ -92,7 +86,7 @@ def create_dictionary_string(
     key_value_join=" ",
     has_empty_fields=False,
 ):
-    """format ordered dictionary as PDF dictionary
+    """format dictionary as PDF dictionary
 
     @param dict_: dictionary of values to render
     @param open: string to open PDF dictionary


### PR DESCRIPTION
Since Python 3.6, dictionaries are always insertion ordered. So there is no need anymore for `collection.OrderedDict()`.

This PR replaces `collection.OrderedDict()` with the standard `dict()`.