### PR TITLE
Save all generated test files in /tmp/pytest-of-$USER

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -107,10 +107,17 @@ When a unit test generates a PDF, it is recommended to use the `assert_pdf_equal
 utility function in order to validate the output.
 It relies on the very handy [qpdf](https://github.com/qpdf/qpdf) CLI program
 to generate a PDF that is easy to compare: annotated, strictly formatted,
-whith uncompressed internal streams.
+with uncompressed internal streams.
 You will need to have its binary in your `$PATH`,
 otherwise `assert_pdf_equal` will fall back to hash-based comparison.
-In order to generate a "reference" PDF file, simply call `assert_pdf_equal` once with `generate=True`.
+
+All generated PDF files (including those processed by `qpdf`) will be stored in
+`/tmp/pytest-of-USERNAME/pytest-current/NAME_OF_TEST/`. By default, three
+last test runs will be saved and then automatically deleted, so you can
+check the output in case of a failed test.
+
+In order to generate a "reference" PDF file, simply call `assert_pdf_equal`
+once with `generate=True`.
 
 Be sure to see the example tests in the `test/` folder in general.
 

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -46,8 +46,12 @@ def assert_pdf_equal(pdf_or_tmpl, rel_expected_pdf_filepath, tmp_path, generate=
     actual_pdf_path = tmp_path / f"actual.pdf"
     pdf.output(actual_pdf_path.open("wb"))
     if QPDF_AVAILABLE:  # Favor qpdf-based comparison, as it helps a lot debugging:
-        actual_lines = _qpdf(actual_pdf_path.read_bytes()).splitlines()
-        expected_lines = _qpdf(expected_pdf_path.read_bytes()).splitlines()
+        actual_qpdf = _qpdf(actual_pdf_path.read_bytes())
+        expected_qpdf = _qpdf(expected_pdf_path.read_bytes())
+        (tmp_path / "actual_qpdf.pdf").write_bytes(actual_qpdf)
+        (tmp_path / "expected_qpdf.pdf").write_bytes(expected_qpdf)
+        actual_lines = actual_qpdf.splitlines()
+        expected_lines = expected_qpdf.splitlines()
         if actual_lines != expected_lines:
             expected_lines = subst_streams_with_hashes(expected_lines)
             actual_lines = subst_streams_with_hashes(actual_lines)


### PR DESCRIPTION
In #82 while converting the tests to pytest and making the `_qpdf` conversion in-memory only, I removed the `delete` argument from `assert_pdf_equal` because it wasn't relevant any more. With this PR all generated data will be stored in the `/tmp/pytest-of-$USER` directory structure and only older test runs will be deleted automatically.

I added an explanation to the docs as well. 