### PR TITLE
tox should send positional args to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ python =
 [testenv]
 deps = -rtest/requirements.txt
 commands =
-  {envpython} -m pytest
+  {envpython} -m pytest {posargs}
 
 [testenv:docs]
 deps = -rdocs/requirements.txt


### PR DESCRIPTION
This allows running `tox -e py39 -- -x --ff -s` with the arguments for pytest