### PR TITLE
Use pathlib.Path in tests

### DIFF
--- a/test/barcodes/test_barcodes.py
+++ b/test/barcodes/test_barcodes.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+
 from fpdf import FPDF
 from test.utilities import assert_pdf_equal
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestBarcodes:
@@ -9,7 +13,7 @@ class TestBarcodes:
         pdf.code39("fpdf2", x=50, y=50, w=4, h=20)
         pdf.set_font("courier", "B", size=36)
         pdf.text(x=80, y=80, txt="fpdf2")
-        assert_pdf_equal(pdf, "barcodes_code39.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "barcodes_code39.pdf", tmp_path)
 
     def test_interleaved2of5(self, tmp_path):
         pdf = FPDF()
@@ -17,4 +21,4 @@ class TestBarcodes:
         pdf.interleaved2of5("1337", x=65, y=50, w=4, h=20)
         pdf.set_font("courier", "B", size=36)
         pdf.text(x=80, y=80, txt="1337")
-        assert_pdf_equal(pdf, "barcodes_interleaved2of5.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "barcodes_interleaved2of5.pdf", tmp_path)

--- a/test/cells/test_cell.py
+++ b/test/cells/test_cell.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+
 import fpdf
 from test.utilities import assert_pdf_equal
 
 TEXT_SIZE, SPACING = 36, 1.15
 LINE_HEIGHT = TEXT_SIZE * SPACING
+
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestCell:
@@ -42,7 +47,9 @@ class TestCell:
                 txt=text[i * 100 : i * 100 + 99],
             )
 
-        assert_pdf_equal(doc, "ln_positioning_and_page_breaking_for_cell.pdf", tmp_path)
+        assert_pdf_equal(
+            doc, HERE / "ln_positioning_and_page_breaking_for_cell.pdf", tmp_path
+        )
 
     def test_cell_ln_0(self, tmp_path):
         doc = fpdf.FPDF()
@@ -52,7 +59,7 @@ class TestCell:
         doc.cell(w=45, h=LINE_HEIGHT, border=1, txt="ipsum")
         doc.cell(w=45, h=LINE_HEIGHT, border=1, txt="Ut")
         doc.cell(w=45, h=LINE_HEIGHT, border=1, txt="nostrud")
-        assert_pdf_equal(doc, "ln_0.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / "ln_0.pdf", tmp_path)
 
     def test_cell_ln_1(self, tmp_path):
         """
@@ -63,7 +70,7 @@ class TestCell:
         doc.set_font("helvetica", size=TEXT_SIZE)
         doc.cell(w=100, h=LINE_HEIGHT, border=1, txt="Lorem ipsum", ln=1)
         doc.cell(w=100, h=LINE_HEIGHT, border=1, txt="Ut nostrud irure")
-        assert_pdf_equal(doc, "ln_1.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / "ln_1.pdf", tmp_path)
 
         doc = fpdf.FPDF()
         doc.add_page()
@@ -71,7 +78,7 @@ class TestCell:
         doc.cell(w=100, h=LINE_HEIGHT, border=1, txt="Lorem ipsum")
         doc.ln()
         doc.cell(w=100, h=LINE_HEIGHT, border=1, txt="Ut nostrud irure")
-        assert_pdf_equal(doc, "ln_1.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / "ln_1.pdf", tmp_path)
 
 
 ## Code used to create this test

--- a/test/cells/test_multi_cell.py
+++ b/test/cells/test_multi_cell.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+
 import fpdf
 from test.utilities import assert_pdf_equal
 
 TEXT_SIZE, SPACING = 36, 1.15
 LINE_HEIGHT = TEXT_SIZE * SPACING
+
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestMultiCell:
@@ -46,7 +51,7 @@ class TestMultiCell:
         doc.cell(w=72 * 2, h=LINE_HEIGHT, border=1, ln=2, txt="Lorem ipsum")
 
         assert_pdf_equal(
-            doc, "ln_positioning_and_page_breaking_for_multicell.pdf", tmp_path
+            doc, HERE / "ln_positioning_and_page_breaking_for_multicell.pdf", tmp_path
         )
 
     def test_multi_cell_ln_0(self, tmp_path):
@@ -57,7 +62,7 @@ class TestMultiCell:
         doc.multi_cell(w=45, h=LINE_HEIGHT, border=1, txt="ipsum")
         doc.multi_cell(w=45, h=LINE_HEIGHT, border=1, txt="Ut")
         doc.multi_cell(w=45, h=LINE_HEIGHT, border=1, txt="nostrud")
-        assert_pdf_equal(doc, "multi_cell_ln_0.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / "multi_cell_ln_0.pdf", tmp_path)
 
     def test_multi_cell_ln_1(self, tmp_path):
         doc = fpdf.FPDF()
@@ -65,7 +70,7 @@ class TestMultiCell:
         doc.set_font("helvetica", size=TEXT_SIZE)
         doc.multi_cell(w=100, h=LINE_HEIGHT, border=1, txt="Lorem ipsum", ln=1)
         doc.multi_cell(w=100, h=LINE_HEIGHT, border=1, txt="Ut nostrud irure")
-        assert_pdf_equal(doc, "multi_cell_ln_1.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / "multi_cell_ln_1.pdf", tmp_path)
 
     def test_multi_cell_ln_3(self, tmp_path):
         doc = fpdf.FPDF()
@@ -75,7 +80,7 @@ class TestMultiCell:
         doc.multi_cell(w=45, h=LINE_HEIGHT, border=1, ln=3, txt="ipsum")
         doc.multi_cell(w=45, h=LINE_HEIGHT, border=1, ln=3, txt="Ut")
         doc.multi_cell(w=45, h=LINE_HEIGHT, border=1, ln=3, txt="nostrud")
-        assert_pdf_equal(doc, "multi_cell_ln_3.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / "multi_cell_ln_3.pdf", tmp_path)
 
     def test_multi_cell_ln_3_table(self, tmp_path):
         """
@@ -108,7 +113,7 @@ class TestMultiCell:
                     max_line_height=pdf.font_size,
                 )
             pdf.ln(line_height)
-        assert_pdf_equal(pdf, "multi_cell_ln_3_table.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "multi_cell_ln_3_table.pdf", tmp_path)
 
 
 ## Code used to create test

--- a/test/class_unit_test/test_shape.py
+++ b/test/class_unit_test/test_shape.py
@@ -1,15 +1,10 @@
-"""issue65_test.py"""
-
-import sys
-import os
-
-sys.path.insert(
-    0,
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.join("..", "..")),
-)
+from pathlib import Path
 
 import fpdf
 from test.utilities import assert_pdf_equal
+
+
+HERE = Path(__file__).resolve().parent
 
 
 def next_row(pdf):
@@ -32,7 +27,7 @@ class TestEllipse:
             if counter % 3 == 0:
                 next_row(pdf)
 
-        assert_pdf_equal(pdf, "class_ellipse_not_circle.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_ellipse_not_circle.pdf", tmp_path)
 
     def test_ellipse_style(self, tmp_path):
         pdf = fpdf.FPDF(unit="mm")
@@ -44,7 +39,7 @@ class TestEllipse:
             if counter % 3 == 0:
                 next_row(pdf)
 
-        assert_pdf_equal(pdf, "class_ellipse_style.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_ellipse_style.pdf", tmp_path)
 
     def test_ellipse_line_width(self, tmp_path):
         pdf = fpdf.FPDF(unit="mm")
@@ -61,7 +56,7 @@ class TestEllipse:
             pdf.set_x(pdf.get_x() + size + margin)
         pdf.set_line_width(0.2)  # reset
 
-        assert_pdf_equal(pdf, "class_ellipse_line_width.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_ellipse_line_width.pdf", tmp_path)
 
     def test_ellipse_draw_color(self, tmp_path):
         pdf = fpdf.FPDF(unit="mm")
@@ -73,7 +68,7 @@ class TestEllipse:
             pdf.ellipse(x=pdf.get_x(), y=pdf.get_y(), w=size, h=size, style=None)
             pdf.set_x(pdf.get_x() + size + margin)
 
-        assert_pdf_equal(pdf, "class_ellipse_draw_color.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_ellipse_draw_color.pdf", tmp_path)
 
     def test_ellipse_fill_color(self, tmp_path):
         pdf = fpdf.FPDF(unit="mm")
@@ -86,7 +81,7 @@ class TestEllipse:
             pdf.set_x(pdf.get_x() + size + margin)
         next_row(pdf)
 
-        assert_pdf_equal(pdf, "class_ellipse_fill_color.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_ellipse_fill_color.pdf", tmp_path)
 
 
 class TestRectangle:
@@ -100,7 +95,7 @@ class TestRectangle:
             if counter % 3 == 0:
                 next_row(pdf)
 
-        assert_pdf_equal(pdf, "class_rect_not_square.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_rect_not_square.pdf", tmp_path)
 
     def test_rect_style(self, tmp_path):
         pdf = fpdf.FPDF(unit="mm")
@@ -112,7 +107,7 @@ class TestRectangle:
             if counter % 3 == 0:
                 next_row(pdf)
 
-        assert_pdf_equal(pdf, "class_rect_style.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_rect_style.pdf", tmp_path)
 
     def test_rect_line_width(self, tmp_path):
         pdf = fpdf.FPDF(unit="mm")
@@ -129,7 +124,7 @@ class TestRectangle:
             pdf.set_x(pdf.get_x() + size + margin)
         pdf.set_line_width(0.2)  # reset
 
-        assert_pdf_equal(pdf, "class_rect_line_width.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_rect_line_width.pdf", tmp_path)
 
     def test_rect_draw_color(self, tmp_path):
         pdf = fpdf.FPDF(unit="mm")
@@ -142,7 +137,7 @@ class TestRectangle:
             pdf.rect(x=pdf.get_x(), y=pdf.get_y(), w=size, h=size, style=None)
             pdf.set_x(pdf.get_x() + size + margin)
 
-        assert_pdf_equal(pdf, "class_rect_draw_color.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_rect_draw_color.pdf", tmp_path)
 
     def test_rect_fill_color(self, tmp_path):
         pdf = fpdf.FPDF(unit="mm")
@@ -156,7 +151,7 @@ class TestRectangle:
 
         next_row(pdf)
 
-        assert_pdf_equal(pdf, "class_rect_fill_color.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_rect_fill_color.pdf", tmp_path)
 
 
 class TestLine:
@@ -179,7 +174,7 @@ class TestLine:
             pdf.set_x(pdf.get_x() + size + margin)
         next_row(pdf)
 
-        assert_pdf_equal(pdf, "class_line.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_line.pdf", tmp_path)
 
     def test_dash(self, tmp_path):
         pdf = fpdf.FPDF(unit="mm")
@@ -218,4 +213,4 @@ class TestLine:
         x, y = pdf.get_x(), pdf.get_y()
         pdf.dashed_line(x, y, x + 100, y + 80, 6, 17)
 
-        assert_pdf_equal(pdf, "class_dash.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "class_dash.pdf", tmp_path)

--- a/test/end_to_end_legacy/charmap/test_charmap.py
+++ b/test/end_to_end_legacy/charmap/test_charmap.py
@@ -9,14 +9,15 @@ the range of the C 'short' data type (2 bytes, 0 - 65535):
   fpdf/ttfonts.py:671: UserWarning: cmap value too big/small:
 and this seems to be okay.
 """
-import os
-from glob import glob
+from pathlib import Path
 
 import pytest
 
 import fpdf
 from fpdf.ttfonts import TTFontFile
-from test.utilities import assert_pdf_equal, relative_path_to
+from test.utilities import assert_pdf_equal
+
+HERE = Path(__file__).resolve().parent
 
 
 class MyTTFontFile(TTFontFile):
@@ -44,8 +45,8 @@ class TestCharmap:
         ["DejaVuSans.ttf", "DroidSansFallback.ttf", "Roboto-Regular.ttf", "cmss12.ttf"],
     )
     def test_first_999_chars(self, fontpath, tmp_path):
-        fontname = os.path.splitext(fontpath)[0]
-        fontpath = relative_path_to(fontpath)
+        fontpath = HERE / fontpath
+        fontname = fontpath.stem
 
         pdf = fpdf.FPDF()
         pdf.add_page()
@@ -62,8 +63,9 @@ class TestCharmap:
             if counter >= 999:
                 break
 
-        assert_pdf_equal(pdf, f"charmap_first_999_chars-{fontname}.pdf", tmp_path)
+        assert_pdf_equal(
+            pdf, HERE / f"charmap_first_999_chars-{fontname}.pdf", tmp_path
+        )
 
-    def tearDown(self):
-        for pkl_filepath in glob(relative_path_to("*") + "*.pkl"):
-            os.remove(pkl_filepath)
+        for pkl_path in HERE.glob("*.pkl"):
+            pkl_path.unlink()

--- a/test/fonts/test_fonts.py
+++ b/test/fonts/test_fonts.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 import pytest
 
 from fpdf import FPDF
 from fpdf.errors import FPDFException
 from test.utilities import assert_pdf_equal
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestFonts:
@@ -42,7 +46,7 @@ class TestFonts:
                 pdf.set_font(font_name.capitalize(), style, 36)
                 pdf.set_font(font_name.lower(), style, 36)
                 pdf.text(0, 10 + 40 * i + 10 * j, "Hello World!")
-        assert_pdf_equal(pdf, "fonts_set_builtin_font.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "fonts_set_builtin_font.pdf", tmp_path)
 
     def test_issue_66(self, tmp_path):
         pdf = FPDF()
@@ -53,4 +57,4 @@ class TestFonts:
         pdf.cell(50, 0, "DEF")
         # Setting the font to an already used one used to remove the text!
         pdf.set_font("Times", "B", 14)
-        assert_pdf_equal(pdf, "fonts_issue_66.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "fonts_issue_66.pdf", tmp_path)

--- a/test/html/test_html.py
+++ b/test/html/test_html.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+
 import pytest
 
 import fpdf
 from fpdf.html import px2mm
-from test.utilities import assert_pdf_equal, relative_path_to
+from test.utilities import assert_pdf_equal
+
+
+HERE = Path(__file__).resolve().parent
 
 
 class MyFPDF(fpdf.FPDF, fpdf.HTMLMixin):
@@ -22,9 +27,7 @@ class TestHTML:
         assert round(pdf.get_y()) == 10
         assert round(pdf.w) == 210
 
-        img_path = relative_path_to(
-            "../image/png_images/c636287a4d7cb1a36362f7f236564cef.png"
-        )
+        img_path = HERE.parent / "image/png_images/c636287a4d7cb1a36362f7f236564cef.png"
         pdf.write_html(
             f"<center><img src=\"{img_path}\" height='300' width='300'></center>"
         )
@@ -33,7 +36,7 @@ class TestHTML:
         assert round(pdf.get_x()) == 10
         assert pdf.get_y() == pytest.approx(mm_after_image, abs=0.01)
 
-        assert_pdf_equal(pdf, "html_images.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "html_images.pdf", tmp_path)
 
     def test_html_features(self, tmp_path):
         pdf = MyFPDF()
@@ -172,12 +175,10 @@ class TestHTML:
         )
 
         pdf.add_page()
-        img_path = relative_path_to(
-            "../image/png_images/c636287a4d7cb1a36362f7f236564cef.png"
-        )
+        img_path = HERE.parent / "image/png_images/c636287a4d7cb1a36362f7f236564cef.png"
         pdf.write_html(f"<img src=\"{img_path}\" height='300' width='300'>")
 
-        assert_pdf_equal(pdf, "html_features.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "html_features.pdf", tmp_path)
 
     def test_html_simple_table(self, tmp_path):
         pdf = MyFPDF()
@@ -192,7 +193,7 @@ class TestHTML:
             <td>4</td><td>5</td><td>6</td>
         </tr></tbody></table>"""
         )
-        assert_pdf_equal(pdf, "html_simple_table.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "html_simple_table.pdf", tmp_path)
 
     def test_html_table_line_separators(self, tmp_path):
         pdf = MyFPDF()
@@ -208,7 +209,7 @@ class TestHTML:
         </tr></tbody></table>""",
             table_line_separators=True,
         )
-        assert_pdf_equal(pdf, "html_table_line_separators.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "html_table_line_separators.pdf", tmp_path)
 
     def test_html_table_with_border(self, tmp_path):
         pdf = MyFPDF()
@@ -223,7 +224,7 @@ class TestHTML:
             <td>4</td><td>5</td><td>6</td>
         </tr></tbody></table>"""
         )
-        assert_pdf_equal(pdf, "html_table_with_border.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "html_table_with_border.pdf", tmp_path)
 
     def test_html_bold_italic_underline(self, tmp_path):
         pdf = MyFPDF()
@@ -235,4 +236,4 @@ class TestHTML:
                <U>underlined</U>
                <B><I><U>all at once!</U></I></B>"""
         )
-        assert_pdf_equal(pdf, "html_bold_italic_underline.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "html_bold_italic_underline.pdf", tmp_path)

--- a/test/image/image_types/test_insert_images.py
+++ b/test/image/image_types/test_insert_images.py
@@ -1,8 +1,12 @@
 import sys
+from pathlib import Path
 
 import fpdf
 from PIL import Image
-from test.utilities import assert_pdf_equal, relative_path_to
+from test.utilities import assert_pdf_equal
+
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestInsertImages:
@@ -10,43 +14,43 @@ class TestInsertImages:
         pdf = fpdf.FPDF()
         pdf.compress = False
         pdf.add_page()
-        file_path = relative_path_to("insert_images_insert_jpg.jpg")
+        file_path = HERE / "insert_images_insert_jpg.jpg"
         pdf.image(file_path, x=15, y=15, h=140)
         if sys.platform in ("cygwin", "win32"):
             # Pillow uses libjpeg-turbo on Windows and libjpeg elsewhere,
             # leading to a slightly different image being parsed and included in the PDF:
-            assert_pdf_equal(pdf, "image_types_insert_jpg_windows.pdf", tmp_path)
+            assert_pdf_equal(pdf, HERE / "image_types_insert_jpg_windows.pdf", tmp_path)
         else:
-            assert_pdf_equal(pdf, "image_types_insert_jpg.pdf", tmp_path)
+            assert_pdf_equal(pdf, HERE / "image_types_insert_jpg.pdf", tmp_path)
 
     def test_insert_png(self, tmp_path):
         pdf = fpdf.FPDF()
         pdf.compress = False
         pdf.add_page()
-        file_path = relative_path_to("insert_images_insert_png.png")
+        file_path = HERE / "insert_images_insert_png.png"
         pdf.image(file_path, x=15, y=15, h=140)
-        assert_pdf_equal(pdf, "image_types_insert_png.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "image_types_insert_png.pdf", tmp_path)
 
     def test_insert_bmp(self, tmp_path):
         pdf = fpdf.FPDF()
         pdf.compress = False
         pdf.add_page()
-        file_path = relative_path_to("circle.bmp")
+        file_path = HERE / "circle.bmp"
         pdf.image(file_path, x=15, y=15, h=140)
-        assert_pdf_equal(pdf, "image_types_insert_bmp.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "image_types_insert_bmp.pdf", tmp_path)
 
     def test_insert_gif(self, tmp_path):
         pdf = fpdf.FPDF()
         pdf.compress = False
         pdf.add_page()
-        file_path = relative_path_to("circle.gif")
+        file_path = HERE / "circle.gif"
         pdf.image(file_path, x=15, y=15)
-        assert_pdf_equal(pdf, "image_types_insert_gif.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "image_types_insert_gif.pdf", tmp_path)
 
     def test_insert_pillow(self, tmp_path):
         pdf = fpdf.FPDF()
         pdf.add_page()
-        file_path = relative_path_to("insert_images_insert_png.png")
+        file_path = HERE / "insert_images_insert_png.png"
         img = Image.open(file_path)
         pdf.image(img, x=15, y=15)
-        assert_pdf_equal(pdf, "image_types_insert_pillow.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "image_types_insert_pillow.pdf", tmp_path)

--- a/test/image/png_images/test_png_file.py
+++ b/test/image/png_images/test_png_file.py
@@ -1,10 +1,10 @@
-import os
-
-import pytest
+from pathlib import Path
 
 import fpdf
-from fpdf.errors import FPDFException
-from test.utilities import assert_pdf_equal, relative_path_to
+from test.utilities import assert_pdf_equal
+
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestInsertPNGSuiteFiles:
@@ -12,28 +12,18 @@ class TestInsertPNGSuiteFiles:
         pdf = fpdf.FPDF(unit="pt")
         pdf.compress = False
 
-        not_supported = [
+        not_supported = {
             "e59ec0cfb8ab64558099543dc19f8378.png",  # Interlacing not supported:
             "6c853ed9dacd5716bc54eb59cec30889.png",  # 16-bit depth not supported:
             "ac6343a98f8edabfcc6e536dd75aacb0.png",  # Interlacing not supported:
             "93e6127b9c4e7a99459c558b81d31bc5.png",  # Interlacing not supported:
             "18f9baf3834980f4b80a3e82ad45be48.png",  # Interlacing not supported:
             "51a4d21670dc8dfa8ffc9e54afd62f5f.png",  # Interlacing not supported:
-        ]
+        }
 
-        images = [
-            relative_path_to(f)
-            for f in os.listdir(relative_path_to("."))
-            if f.endswith(".png") and os.path.basename(f) not in not_supported
-        ]
-        images.sort()
-
-        for image in images:
-            if os.path.basename(image) in not_supported:
-                with pytest.raises(FPDFException):
-                    pdf.image(x=0, y=0, w=0, h=0, link=None)
-            else:
+        for path in sorted(HERE.glob("*.png")):
+            if path.name not in not_supported:
                 pdf.add_page()
-                pdf.image(image, x=0, y=0, w=0, h=0, link=None)
+                pdf.image(str(path), x=0, y=0, w=0, h=0, link=None)
 
-        assert_pdf_equal(pdf, "image_png_insert_png_files.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "image_png_insert_png_files.pdf", tmp_path)

--- a/test/image/test_image_info.py
+++ b/test/image/test_image_info.py
@@ -1,10 +1,10 @@
 import json
-import os
 from io import BytesIO
+from pathlib import Path
 
 import fpdf
 
-from test.utilities import relative_path_to
+HERE = Path(__file__).resolve().parent
 
 
 class TestImageParsing:
@@ -29,33 +29,18 @@ class TestImageParsing:
         }
 
     def test_get_img_info(self):
-        img_dir = "png_test_suite/"
-        images = sorted(os.listdir(relative_path_to(img_dir))[:20])
+        short_keys = {"f", "h", "bpc", "w", "cs", "trns", "dp", "pal"}
+        expected = json.loads((HERE / "image_info.json").read_text())
 
-        def isok(image):
-            return image.endswith(".png") and not image.startswith("x")
-
-        images = [image for image in images if isok(image)]
-        # expln = [self.break_down_filename(name) for name in images]
-
-        paths = [os.path.join(relative_path_to(img_dir), i) for i in images]
-        blobs = [BytesIO(get_contents(path)) for path in paths]
-        # modes = [Image.open(blob).mode for blob in blobs]
-
-        infos = [fpdf.image_parsing.get_img_info(blob) for blob in blobs]
-
-        short_keys = ["f", "h", "bpc", "w", "cs", "trns", "dp", "pal"]
-
-        with open(relative_path_to("image_info.json")) as f:
-            expected = json.load(f)
-
-        for info, image in zip(infos, images):
-            short_info = {k: v for k, v in info.items() if k in short_keys}
-            assert short_info == expected[image]
+        for path in sorted((HERE / "png_test_suite").glob("*.png")):
+            if not path.stem.startswith("x"):
+                blob = BytesIO(path.read_bytes())
+                info = fpdf.image_parsing.get_img_info(blob)
+                short_info = {k: v for k, v in info.items() if k in short_keys}
+                assert short_info == expected[path.name]
 
     def test_get_img_info_data_rgba(self):
-        path = os.path.join(relative_path_to("png_test_suite/"), "basi3p02.png")
-        blob = BytesIO(get_contents(path))
+        blob = BytesIO((HERE / "png_test_suite" / "basi3p02.png").read_bytes())
         info = fpdf.image_parsing.get_img_info(blob)
         assert (
             info["data"]
@@ -64,15 +49,9 @@ class TestImageParsing:
         assert info["smask"] == b"x\x9cc\xf8O\x000\x8c*\x18U0\xaa`\xa4*\x00\x00?h\xfc."
 
     def test_get_img_info_data_gray(self):
-        path = os.path.join(relative_path_to("png_test_suite/"), "basi0g08.png")
-        blob = BytesIO(get_contents(path))
+        blob = BytesIO((HERE / "png_test_suite" / "basi0g08.png").read_bytes())
         info = fpdf.image_parsing.get_img_info(blob)
         assert (
             info["data"]
             == b"x\x9cc``dbfaec\xe7\xe0\xe4\xe2\xe6\xe1\xe5\xe3\x17\x10\x14\x12\x16\x11\x15\x13\x97\x90\x94\x92\x96\x91\x95\x93gPPTRVQUS\xd7\xd0\xd4\xd2\xd6\xd1\xd5\xd370426153\xb7\xb0\xb4\xb2\xb6\xb1\xb5\xb3gpptrvqus\xf7\xf0\xf4\xf2\xf6\xf1\xf5\xf3\x0f\x08\x0c\n\x0e\t\r\x0b\x8f\x88\x8c\x8a\x8e\x89\x8d\x8bgHHLJNIMK\xcf\xc8\xcc\xca\xce\xc9\xcd\xcb/(,*.)-+\xaf\xa8\xac\xaa\xae\xa9\xad\xabghhljnimk\xef\xe8\xec\xea\xee\xe9\xed\xeb\x9f0q\xd2\xe4)S\xa7M\x9f1s\xd6\xec9s\xe7\xcdgX\xb0p\xd1\xe2%K\x97-_\xb1r\xd5\xea5k\xd7\xad\xdf\xb0q\xd3\xe6-[\xb7m\xdf\xb1s\xd7\xee={\xf7\xedg8p\xf0\xd0\xe1#G\x8f\x1d?q\xf2\xd4\xe93g\xcf\x9d\xbfp\xf1\xd2\xe5+W\xaf]\xbfq\xf3\xd6\xed;w\xef\xddgx\xf0\xf0\xd1\xe3'O\x9f=\x7f\xf1\xf2\xd5\xeb7o\xdf\xbd\xff\xf0\xf1\xd3\xe7/_\xbf}\xff\xf1\xf3\xd7\xef?\x7f\xff\xfdg\xf8\xf7\xf7\xcf\xef_?\x7f|\xff\xf6\xf5\xcb\xe7O\x1f?\xbc\x7f\xf7\xf6\xcd\xebW/_<\x7f\xf6\xf4\xc9\xe3G\x0f\x1f\xdcg\xb8w\xf7\xce\xed[7o\\\xbfv\xf5\xca\xe5K\x17/\x9c?w\xf6\xcc\xe9S'O\x1c?v\xf4\xc8\xe1C\x07\x0f\xecg\xd8\xb7w\xcf\xee];wl\xdf\xb6u\xcb\xe6M\x1b7\xac_\xb7v\xcd\xeaU+W,_\xb6t\xc9\xe2E\x0b\x17\xccg\x987w\xce\xecY3gL\x9f6u\xca\xe4I\x13'\xf4\xf7\xf5\xf6twuv\xb4\xb7\xb5\xb64756\xd43\xd4\xd5\xd6TWUV\x94\x97\x95\x96\x14\x17\x15\x16\xe4\xe7\xe5\xe6dgef\xa4\xa7\xa5\xa6$'%&\xc43\xc4\xc5\xc6DGEF\x84\x87\x85\x86\x04\x07\x05\x06\xf8\xfb\xf9\xfax{yz\xb8\xbb\xb9\xba8;9:\xd83\xd8\xd9\xdaX[YZ\x98\x9b\x99\x9a\x18\x1b\x19\x1a\xe8\xeb\xe9\xeahkij\xa8\xab\xa9\xaa(+)*\xc83\xc8\xc9\xcaHKIJ\x88\x8b\x89\x8a\x08\x0b\t\n\xf0\xf3\xf1\xf2psqr\xb0\xb3\xb1\xb2031202\xe0O\r\n\x8a\x0c\xf8S\x83\x83#\x03\xfe\xd4\x90\x90\xc8\x80?5442\xe0O\r\x0b\x162\xe0O\r\x07\x0e2\xe0O\r\x0f\x1e2\xe0O\r\xff\xfe2\xe0O\r\xf7\xee2\xe0O\r\xfb\xf62\xe0O\r\xf3\xe62\xe0O\ru\xb5\x0c\xf8SC\\,\x03\xfe\xd4`g\xcb\x80?5\xc8\xc92\xe0O\rL\xcc\x00\x17\xb3\xfc\x18"
         )
-
-
-def get_contents(path):
-    with open(path, "rb") as f:
-        return f.read()

--- a/test/image/test_load_resource.py
+++ b/test/image/test_load_resource.py
@@ -1,13 +1,15 @@
 """load_resource.py"""
 
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 
 import fpdf
 from fpdf.errors import FPDFException
 
-from test.utilities import relative_path_to
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestLoadResource:
@@ -24,11 +26,9 @@ class TestLoadResource:
         assert msg == str(e.value)
 
     def test_load_text_file(self):
-        file = relative_path_to("__init__.py")
+        file = HERE / "__init__.py"
         contents = '"""This package contains image tests"""\n'
-        bc = contents.encode("utf-8")
+        bc = contents.encode()
 
-        resource = fpdf.image_parsing.load_resource(file).getvalue()
+        resource = fpdf.image_parsing.load_resource(str(file)).getvalue()
         assert bytes(resource) == bc
-        # print(bytes(resource))
-        # print(bc)

--- a/test/image/test_url_images.py
+++ b/test/image/test_url_images.py
@@ -1,19 +1,12 @@
-import sys
-import os
+from pathlib import Path
 
 import pytest
 
-sys.path.insert(
-    0,
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), os.path.join("..", "..", "..")
-    ),
-)
 
 import fpdf
 from test.utilities import assert_pdf_equal
 
-# python -m unittest test.image.url_images
+HERE = Path(__file__).resolve().parent
 
 
 @pytest.mark.skip("skip network tests by default")
@@ -24,7 +17,7 @@ class TestUrlImages:
         pdf.add_page()
         png = "https://upload.wikimedia.org/wikipedia/commons/7/70/Example.png"
         pdf.image(png, x=15, y=15, w=30, h=25)
-        assert_pdf_equal(pdf, "image_png_url.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "image_png_url.pdf", tmp_path)
 
     def test_jpg_url(self, tmp_path):
         pdf = fpdf.FPDF()
@@ -35,7 +28,7 @@ class TestUrlImages:
             "JPEG_example_JPG_RIP_025.jpg"
         )
         pdf.image(jpg, x=15, y=15)
-        assert_pdf_equal(pdf, "image_jpg_url.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "image_jpg_url.pdf", tmp_path)
 
 
 ## Code used to create test:

--- a/test/template/test_template.py
+++ b/test/template/test_template.py
@@ -1,6 +1,10 @@
+from pathlib import Path
+
 from fpdf.template import Template
 
-from test.utilities import assert_pdf_equal, relative_path_to
+from test.utilities import assert_pdf_equal
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestTemplate:
@@ -119,13 +123,13 @@ class TestTemplate:
         tmpl = Template(format="A4", elements=elements, title="Sample Invoice")
         tmpl.add_page()
         tmpl["company_name"] = "Sample Company"
-        tmpl["company_logo"] = relative_path_to("../../docs/fpdf2-logo.png")
-        assert_pdf_equal(tmpl, "template_nominal_hardcoded.pdf", tmp_path)
+        tmpl["company_logo"] = HERE.parent.parent / "docs/fpdf2-logo.png"
+        assert_pdf_equal(tmpl, HERE / "template_nominal_hardcoded.pdf", tmp_path)
 
     def test_nominal_csv(self, tmp_path):
         "Taken from docs/Templates.md"
         tmpl = Template(format="A4", title="Sample Invoice")
-        tmpl.parse_csv(relative_path_to("mycsvfile.csv"), delimiter=";")
+        tmpl.parse_csv(HERE / "mycsvfile.csv", delimiter=";")
         tmpl.add_page()
         tmpl["company_name"] = "Sample Company"
-        assert_pdf_equal(tmpl, "template_nominal_csv.pdf", tmp_path)
+        assert_pdf_equal(tmpl, HERE / "template_nominal_csv.pdf", tmp_path)

--- a/test/test_alias.py
+++ b/test/test_alias.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+
 import fpdf
 from test.utilities import assert_pdf_equal
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestAlias:
@@ -10,7 +14,7 @@ class TestAlias:
         pdf.cell(0, 10, f"Page {pdf.page_no()}/{{nb}}", align="C")
         pdf.add_page()
         pdf.cell(0, 10, f"Page {pdf.page_no()}/{{nb}}", align="C")
-        assert_pdf_equal(pdf, "alias_nb_pages.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "alias_nb_pages.pdf", tmp_path)
 
     def test_custom_alias_nb_pages(self, tmp_path):
         pdf = fpdf.FPDF()
@@ -26,4 +30,4 @@ class TestAlias:
         pdf.cell(0, 10, f"Page {pdf.page_no()}/{alias}", align="C")
         pdf.add_page()
         pdf.cell(0, 10, f"Page {pdf.page_no()}/{alias}", align="C")
-        assert_pdf_equal(pdf, "alias_nb_pages.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "alias_nb_pages.pdf", tmp_path)

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -1,7 +1,12 @@
+from pathlib import Path
+
 import pytest
 
 import fpdf
 from test.utilities import assert_pdf_equal
+
+
+HERE = Path(__file__).resolve().parent
 
 
 def document_operations(doc):
@@ -18,11 +23,11 @@ class TestCatalogDisplayMode:
         doc = fpdf.FPDF()
         document_operations(doc)
         doc.set_display_mode(zoom=zoom_input, layout="continuous")
-        assert_pdf_equal(doc, f"catalog-zoom-{zoom_input}.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / f"catalog-zoom-{zoom_input}.pdf", tmp_path)
 
     @pytest.mark.parametrize("layout_input", ["single", "continuous", "two", "default"])
     def test_setting_all_layout(self, layout_input, tmp_path):
         doc = fpdf.FPDF()
         document_operations(doc)
         doc.set_display_mode(zoom="default", layout=layout_input)
-        assert_pdf_equal(doc, f"catalog-layout-{layout_input}.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / f"catalog-layout-{layout_input}.pdf", tmp_path)

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+
 import fpdf
 from test.utilities import assert_pdf_equal
+
+HERE = Path(__file__).resolve().parent
 
 
 def document_operations(doc):
@@ -19,7 +23,7 @@ class TestCatalogDisplayMode:
         doc.set_author("sample author")
         doc.set_keywords("sample keywords")
         doc.set_creator("sample creator")
-        assert_pdf_equal(doc, "put_info_all.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / "put_info_all.pdf", tmp_path)
 
     def test_put_info_some(self, tmp_path):
         doc = fpdf.FPDF()
@@ -29,4 +33,4 @@ class TestCatalogDisplayMode:
         # doc.set_author('sample author')
         doc.set_keywords("sample keywords")
         doc.set_creator("sample creator")
-        assert_pdf_equal(doc, "put_info_some.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / "put_info_some.pdf", tmp_path)

--- a/test/test_rotation.py
+++ b/test/test_rotation.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+
 from fpdf import FPDF
-from test.utilities import assert_pdf_equal, relative_path_to
+from test.utilities import assert_pdf_equal
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestRotate:
@@ -7,10 +11,8 @@ class TestRotate:
         pdf = FPDF()
         pdf.add_page()
         x, y = 60, 60
-        img_filepath = relative_path_to(
-            "image/png_images/66ac49ef3f48ac9482049e1ab57a53e9.png"
-        )
+        img_filepath = HERE / "image/png_images/66ac49ef3f48ac9482049e1ab57a53e9.png"
         with pdf.rotation(45, x=x, y=y):
             pdf.image(img_filepath, x=x, y=y)
         pdf.image(img_filepath, x=150, y=150)
-        assert_pdf_equal(pdf, "rotation.pdf", tmp_path)
+        assert_pdf_equal(pdf, HERE / "rotation.pdf", tmp_path)

--- a/test/test_set_date.py
+++ b/test/test_set_date.py
@@ -1,10 +1,14 @@
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
 import fpdf
 from fpdf.errors import FPDFException
 from test.utilities import assert_pdf_equal
+
+
+HERE = Path(__file__).resolve().parent
 
 
 class TestCreationDate:
@@ -20,4 +24,4 @@ class TestCreationDate:
         # 2017, April 18th, almost 7:09a
         date = datetime(2017, 4, 18, 7, 8, 55)
         doc.set_creation_date(date)
-        assert_pdf_equal(doc, "setting_old_date.pdf", tmp_path)
+        assert_pdf_equal(doc, HERE / "setting_old_date.pdf", tmp_path)

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -1,12 +1,8 @@
 import datetime as dt
 import hashlib
-import inspect
-import os
 import subprocess
 import shutil
-import sys
 import warnings
-from pathlib import Path
 
 from fpdf.template import Template
 
@@ -17,7 +13,7 @@ if not QPDF_AVAILABLE:
     )
 
 
-def assert_pdf_equal(pdf_or_tmpl, rel_expected_pdf_filepath, tmp_path, generate=False):
+def assert_pdf_equal(pdf_or_tmpl, expected_pdf_path, tmp_path, generate=False):
     """
     This compare the output of a `FPDF` instance (or `Template` instance),
     with the provided PDF file.
@@ -29,7 +25,7 @@ def assert_pdf_equal(pdf_or_tmpl, rel_expected_pdf_filepath, tmp_path, generate=
 
     Args:
         pdf_or_tmpl: instance of `FPDF` or `Template`. The `output` or `render` method will be called on it.
-        rel_expected_pdf_filepath (str): relative file path to a PDF file matching the expected output
+        expected_pdf_path (str): file path to a PDF file matching the expected output
         tmp_path (Path): temporary directory provided by pytest individually to the caller test function
         generate (bool): only generate `pdf` output to `rel_expected_pdf_filepath` and return. Useful to create new tests.
     """
@@ -39,11 +35,10 @@ def assert_pdf_equal(pdf_or_tmpl, rel_expected_pdf_filepath, tmp_path, generate=
     else:
         pdf = pdf_or_tmpl
     pdf.set_creation_date(dt.datetime.fromtimestamp(0, dt.timezone.utc))
-    expected_pdf_path = Path(relative_path_to(rel_expected_pdf_filepath, depth=2))
     if generate:
         pdf.output(expected_pdf_path.open("wb"))
         return
-    actual_pdf_path = tmp_path / f"actual.pdf"
+    actual_pdf_path = tmp_path / "actual.pdf"
     pdf.output(actual_pdf_path.open("wb"))
     if QPDF_AVAILABLE:  # Favor qpdf-based comparison, as it helps a lot debugging:
         actual_lines = _qpdf(actual_pdf_path.read_bytes()).splitlines()
@@ -107,14 +102,3 @@ def _qpdf(pdf_data):
         stderr=subprocess.PIPE,
     )
     return proc.communicate(input=pdf_data)[0]
-
-
-def relative_path_to(place, depth=1):
-    """Finds Relative Path to a place
-
-    Works by getting the file of the caller module, then joining the directory
-    of that absolute path and the place in the argument.
-    """
-    # pylint: disable=protected-access
-    caller_file = inspect.getfile(sys._getframe(depth))
-    return os.path.abspath(os.path.join(os.path.dirname(caller_file), place))

--- a/test/utils/test_load_cache.py
+++ b/test/utils/test_load_cache.py
@@ -1,15 +1,6 @@
-# """load_cache.py"""
-
-import os
 import pickle
 
 import fpdf
-
-
-# with open('filename.pickle', 'rb') as handle:
-#     b = pickle.load(handle)
-
-# print a == b
 
 
 class TestLoadCache:
@@ -17,12 +8,11 @@ class TestLoadCache:
         result = fpdf.fpdf.load_cache(None)
         assert result is None
 
-    def test_load_cache_pickle(self):
+    def test_load_cache_pickle(self, tmp_path):
+        path = tmp_path / "filename.pickle"
         a = {"hello": "world"}
-        with open("filename.pickle", "wb") as handle:
+        with path.open("wb") as handle:
             pickle.dump(a, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
-        assert fpdf.fpdf.load_cache("filename.pickle") == a
-        assert fpdf.fpdf.load_cache("filename1.pickle") is None
-
-        os.unlink("filename.pickle")
+        assert fpdf.fpdf.load_cache(path) == a
+        assert fpdf.fpdf.load_cache(path.with_name("filename1.pickle")) is None


### PR DESCRIPTION
Use `pathlib.Path` for directory/files manipulation in the tests. Remove the `relative_path_to` method.

No change outside of the `test` directory. 