### PR TITLE
add default argument to alias_nb_pages()

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -475,7 +475,7 @@ class FPDF:
         else:
             raise FPDFException(f'Unknown document option "{opt}"')
 
-    def alias_nb_pages(self, alias):
+    def alias_nb_pages(self, alias="{nb}"):
         """Define an alias for total number of pages"""
         self.str_alias_nb_pages = alias
 


### PR DESCRIPTION
Just a minor edit but improves compatibility to legacy pyfpdf code.

The previous definition was inconsistent with the documentation:
 https://pyfpdf.github.io/fpdf2/reference/alias_nb_pages.html
which also led to the example not working.
`TypeError: alias_nb_pages() missing 1 required positional argument: 'alias'`

Using a default argument here can be a handy way to reset to default values.
