### PR TITLE
Fix bug in deprecation.py

### DIFF
--- a/fpdf/deprecation.py
+++ b/fpdf/deprecation.py
@@ -14,7 +14,7 @@ class WarnOnDeprecatedModuleAttributes(ModuleType):
             )
             return None
         # pylint: disable=no-member
-        return super().__getattr__(self, name)
+        return super().__getattr__(name)
 
     def __setattr__(self, name, value):
         if name in ("FPDF_CACHE_DIR", "FPDF_CACHE_MODE"):

--- a/fpdf/deprecation.py
+++ b/fpdf/deprecation.py
@@ -26,4 +26,4 @@ class WarnOnDeprecatedModuleAttributes(ModuleType):
                 stacklevel=2,
             )
             return
-        super().__setattr__(self, name, value)
+        super().__setattr__(name, value)

--- a/test/fonts/test_add_font.py
+++ b/test/fonts/test_add_font.py
@@ -39,6 +39,9 @@ def test_deprecation_warning_for_FPDF_CACHE_DIR():
     with pytest.warns(DeprecationWarning):
         fpdf.FPDF_CACHE_MODE = 1
 
+    fpdf.SOME = 1
+    assert fpdf.SOME == 1
+
     import fpdf
 
     with pytest.warns(DeprecationWarning):
@@ -49,6 +52,9 @@ def test_deprecation_warning_for_FPDF_CACHE_DIR():
         fpdf.FPDF_CACHE_MODE
     with pytest.warns(DeprecationWarning):
         fpdf.FPDF_CACHE_MODE = 1
+
+    fpdf.SOME = 1
+    assert fpdf.SOME == 1
 
 
 def test_add_font_unicode_with_path_fname_ok(tmp_path):


### PR DESCRIPTION
Fixed the call to super().__setattr__() causing an "expected 2 arguments, got 3" exception in Python 3.