### PR TITLE
Fix windows qpdf tests

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ On [fpdf2](https://github.com/pyfpdf/fpdf2/graphs/contributors):
 - Abishek Goda
 - xitrushiy
 - Miroslav Šedivý
+- Arthur Moore
 
 On the original [PyFPDF](https://github.com/reingart/pyfpdf/graphs/contributors):
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -127,11 +127,11 @@ def _qpdf(input_pdf_filepath):
         # Lucas (2021/01/06) : this conversion of UNIX file paths to Windows ones is only needed
         # for my development environment: Cygwin, a UNIX system, with a qpdf Windows binary. Sorry for the kludge!
         input_pdf_filepath = (
-            check_output(["cygpath", "-w", input_pdf_filepath]).decode().strip()
+            check_output(["cygpath", "-w", str(input_pdf_filepath)]).decode().strip()
         )
     try:
         return check_output(
-            ["qpdf", "--deterministic-id", "--qdf", input_pdf_filepath, "-"],
+            ["qpdf", "--deterministic-id", "--qdf", str(input_pdf_filepath), "-"],
             stderr=PIPE,
         )
     except CalledProcessError as error:


### PR DESCRIPTION
The tests were failing on Windows because of a WindowsPath issue.

Making sure it is converted to a string fixes the problem.