### PR TITLE
Bugfix to preserve numeric values when using CSV based templates

### DIFF
--- a/fpdf/template.py
+++ b/fpdf/template.py
@@ -94,6 +94,10 @@ class Template:
                     if not v.startswith("'") and decimal_sep != ".":
                         v = v.replace(decimal_sep, ".")
                     kargs[keys[i]] = v.strip()
+                try: 
+                    kargs[keys[i]]=float(kargs[keys[i]])
+                except ValueError:
+                    continue
                 self.elements.append(kargs)
         self.keys = [v["name"].lower() for v in self.elements]
 


### PR DESCRIPTION
When reading the template fro a CSV file, all values in the elements dictionary end up as strings wich in turn causes problems with some other functions that rely on mathematical operators (e.g. the ```rgb(col)``` function). This is a quick fix to try to preserve numeric values.