### PR TITLE
Fixed `assert_pdf_equal` not working when "expected" is an instance of FPDF

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -61,6 +61,7 @@ def assert_pdf_equal(actual, expected, tmp_path, generate=False):
             if isinstance(expected, (bytes, bytearray)):
                 pdf_file.write(expected)
             else:
+                expected.set_creation_date(EPOCH)
                 expected.output(pdf_file)
     actual_pdf_path = tmp_path / "actual.pdf"
     with actual_pdf_path.open("wb") as pdf_file:


### PR DESCRIPTION
Tests relying on this functionality will fail because the "expected" pdf will be generated without the date being handled.

Test to exercise this functionality is in the other pull request.

You can verify the code path is never used/tested currently by modifying your `.coveragerc` file with:
>     test/*.py
>     test/**/*.py
