### PR TITLE
Support multi-lines text in table cells with write_html - fix #91

### DIFF
--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -214,7 +214,7 @@ class HTML2FPDF(HTMLParser):
         # divyaman edits {
         self.top_position_x = -1
         self.top_position_y = -1
-        #}
+        # }
         self.image_map = image_map or (lambda src: src)
         self.li_tag_indent = li_tag_indent
         self.table_line_separators = table_line_separators
@@ -391,7 +391,7 @@ class HTML2FPDF(HTMLParser):
             # divyaman edit {
             width = 0
             for i in self.table_col_width:
-                
+
                 self.output_table_sep_vertical(width)
                 width += self.width2unit(i)
             self.output_table_sep_vertical(width)
@@ -404,10 +404,16 @@ class HTML2FPDF(HTMLParser):
         width = sum(self.width2unit(length) for length in self.table_col_width)
         self.pdf.line(x1, y1, x1 + width, y1)
 
-    #divyaman edits {
+    # divyaman edits {
     def output_table_sep_vertical(self, width):
         y1 = self.pdf.y
-        self.pdf.line(self.top_position_x+width, self.top_position_y, self.top_position_x+width, y1)
+        self.pdf.line(
+            self.top_position_x + width,
+            self.top_position_y,
+            self.top_position_x + width,
+            y1,
+        )
+
     # }
 
     def handle_starttag(self, tag, attrs):
@@ -507,11 +513,15 @@ class HTML2FPDF(HTMLParser):
             if attrs:
                 self.align = attrs.get("align")
             self._only_imgs_in_td = False
-             # divyaman edit {
-            
-            self.top_position_x = self.pdf.x if(self.top_position_x == -1) else self.top_position_x
-            self.top_position_y = self.pdf.y if(self.top_position_y == -1) else self.top_position_y
-            # } 
+            # divyaman edit {
+
+            self.top_position_x = (
+                self.pdf.x if (self.top_position_x == -1) else self.top_position_x
+            )
+            self.top_position_y = (
+                self.pdf.y if (self.top_position_y == -1) else self.top_position_y
+            )
+            # }
 
         if tag == "th":
             self.td = {k.lower(): v for k, v in attrs.items()}
@@ -703,10 +713,10 @@ class HTMLMixin:
         # Method arguments must override class & instance attributes:
         kwargs2.update(kwargs)
         h2p = HTML2FPDF(self, *args, **kwargs2)
-        
+
         # divyaman edits {
-        text = text.replace("\n", "<br>") # this is my change
-        #}
+        text = text.replace("\n", "<br>")  # this is my change
+        # }
 
         text = html.unescape(text)  # To deal with HTML entities
         h2p.feed(text)

--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -211,6 +211,10 @@ class HTML2FPDF(HTMLParser):
         """
         super().__init__()
         self.pdf = pdf
+        # divyaman edits {
+        self.top_position_x = -1
+        self.top_position_y = -1
+        #}
         self.image_map = image_map or (lambda src: src)
         self.li_tag_indent = li_tag_indent
         self.table_line_separators = table_line_separators
@@ -384,6 +388,14 @@ class HTML2FPDF(HTMLParser):
             self.pdf.set_x(x)
         if self.table.get("border"):
             self.output_table_sep()
+            # divyaman edit {
+            width = 0
+            for i in self.table_col_width:
+                
+                self.output_table_sep_vertical(width)
+                width += self.width2unit(i)
+            self.output_table_sep_vertical(width)
+            # }
         self.tfooter_out = True
 
     def output_table_sep(self):
@@ -391,6 +403,12 @@ class HTML2FPDF(HTMLParser):
         y1 = self.pdf.y
         width = sum(self.width2unit(length) for length in self.table_col_width)
         self.pdf.line(x1, y1, x1 + width, y1)
+
+    #divyaman edits {
+    def output_table_sep_vertical(self, width):
+        y1 = self.pdf.y
+        self.pdf.line(self.top_position_x+width, self.top_position_y, self.top_position_x+width, y1)
+    # }
 
     def handle_starttag(self, tag, attrs):
         attrs = dict(attrs)
@@ -489,6 +507,12 @@ class HTML2FPDF(HTMLParser):
             if attrs:
                 self.align = attrs.get("align")
             self._only_imgs_in_td = False
+             # divyaman edit {
+            
+            self.top_position_x = self.pdf.x if(self.top_position_x == -1) else self.top_position_x
+            self.top_position_y = self.pdf.y if(self.top_position_y == -1) else self.top_position_y
+            # } 
+
         if tag == "th":
             self.td = {k.lower(): v for k, v in attrs.items()}
             self.th = True
@@ -679,5 +703,10 @@ class HTMLMixin:
         # Method arguments must override class & instance attributes:
         kwargs2.update(kwargs)
         h2p = HTML2FPDF(self, *args, **kwargs2)
+        
+        # divyaman edits {
+        text = text.replace("\n", "<br>") # this is my change
+        #}
+
         text = html.unescape(text)  # To deal with HTML entities
         h2p.feed(text)


### PR DESCRIPTION
### **Table Data Tuple** 
`data = (`
    &emsp;`("First name ", "Last name ", "Age", "City"),`
    &emsp;`("Chandrapratap singh \ntomer rajput ", "Smith this can \nalso see this err \nokay", "34", "San Juan"),`
    &emsp;`("Mary \nthis is the \ncorrection", "Ramos \n also this \n over laping data \nto se the error ", "45", "Orlando"),`
    &emsp;`("Carlson data \ncan be multiline ", "Banks", "19 \n32", "Los Angeles \nthis to"),`
    &emsp;`("Lucas \nnot working ", "Cimon \nsame to see the \nerror in prev", "31", "Saint-Mahturin-sur-Loire \nthis also"),`
`)`



![image](https://user-images.githubusercontent.com/54167912/131262939-fe0711d2-7ee5-4998-9c1e-a5cd8a722cbd.png)
### **                                        fig 1: table before adding multi-line text support.**

![image](https://user-images.githubusercontent.com/54167912/131262822-af85bf5b-330c-4033-8686-02439b267b13.png)
### **                                       fig 2: table after adding multi-line text support.**

firstly I replaced the \n(in data) by <br> tag
`        text = text.replace("\n", "<br>") `
then I get the coordinates of the table 

` self.top_position_x = self.pdf.x if(self.top_position_x == -1) else self.top_position_x`
`  self.top_position_y = self.pdf.y if(self.top_position_y == -1) else self.top_position_y`

and created a function to make vertical lines using above coordinates 
`def output_table_sep_vertical(self, width):`
 &emsp; `y1 = self.pdf.y`
&emsp; `self.pdf.line(self.top_position_x+width, self.top_position_y, self.top_position_x+width, y1)`

Now this function will be called equal to the number of columns in the table.


`width = 0`
`for i in self.table_col_width:`
&emsp; `self.output_table_sep_vertical(width)`
&emsp; `width += self.width2unit(i)`
`self.output_table_sep_vertical(width)`