### PR TITLE
WIP: multi-line cells in table

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -1893,7 +1893,7 @@ class FPDF:
         Args:
             w (int): cell width. If 0, they extend up to the right margin of the page.
             h (int): cell height. Default value: None, meaning to use the current font size.
-            txt (str): strign to print.
+            txt (str): string to print.
             border: Indicates if borders must be drawn around the cell.
                 The value can be either a number (`0`: no border ; `1`: frame)
                 or a string containing some or all of the following characters

--- a/fpdf/table.py
+++ b/fpdf/table.py
@@ -1,0 +1,65 @@
+
+class Table():
+
+    """A pdf table"""
+
+    def __init__(self):
+
+        self.html_content = None
+        self.html_attrs = None
+        self.images = None
+
+        # self.text_content = []   # table cell contents: data[n_rows][n_cols]
+        # self.image_contents  = [] #
+        #
+        self.width = None # width of the table
+        self.table_offset = 0
+
+        self.colwidths = [] # column widhts in pct [n_cols]
+        self.header = [] # optional: header contents [n_cols]
+        self.footer = [] # optional: header contents [n_cols]
+        self.do_border = False
+
+        self._cell_active = False # are we inside <td> ?
+
+    def tr_start(self):
+        """Adds an empty list of html_content (equivalent to <tr>)"""
+        if self.html_content is None:
+            self.html_content = [[]]
+            self.html_attrs = [[]]
+            self.images = [[]]
+        else:
+            self.html_content.append([])
+            self.html_attrs.append([])
+            self.images.append([])
+
+    def tr_close(self):
+        pass
+
+    def td_start(self, attrs = None):
+        """Adds a cell to html_content (equivalent to <td>)"""
+        self.html_content[-1].append('')
+        self.html_attrs[-1].append(attrs)
+        self.images[-1].append(None)
+
+        self._cell_active = True
+
+    def td_close(self):
+        self._cell_active = False
+
+    def add_image(self, attrs):
+        """Adds a image to the current cell - only a single image can be present in each cell"""
+        if self._cell_active:
+            self.images[-1][-1] = attrs
+
+
+    def add_data(self, data):
+        """Adds data to the current cell - if any"""
+
+        if self._cell_active:
+            self.html_content[-1][-1] += data
+
+    def insert(self, pdf):
+        """Inserts the table at the current location in the pdf"""
+        print('inserting table')
+

--- a/test/html/test_html.py
+++ b/test/html/test_html.py
@@ -288,19 +288,28 @@ def test_customize_ul(tmp_path):
 def test_img_inside_html_table(tmp_path):
     pdf = MyFPDF()
     pdf.add_page()
+
+
+
     pdf.write_html(
         """<table>
         <tr>
             <td width="50%">
-                <img src="test/image/png_images/affc57dfffa5ec448a0795738d456018.png" height="235" width="435"/>
+                <img src="C:/data/python/fpdf2/test/image/png_images/affc57dfffa5ec448a0795738d456018.png" height="235" width="435"/>
             </td>
             <td width="50%">
-                <img src="test/image/image_types/insert_images_insert_png.png" height="162" width="154"/>
+                <img src="C:/data/python/fpdf2/test/image/png_images/affc57dfffa5ec448a0795738d456018.png" height="162" width="154"/>
+                text below image
             </td>
         </tr>
+        <tr>
+        <td>cell</td><td>cell2</td></tr>
     </table>"""
     )
-    assert_pdf_equal(pdf, HERE / "test_img_inside_html_table.pdf", tmp_path)
+
+    pdf.output('c:/data/test.pdf')
+
+    # assert_pdf_equal(pdf, HERE / "test_img_inside_html_table.pdf", tmp_path)
 
 
 def test_img_inside_html_table_without_explicit_dimensions(tmp_path):
@@ -428,3 +437,23 @@ def test_html_font_color_name(tmp_path):
         '<font color="beige"><p><i>italic hello in beige</i></p></font>'
     )
     assert_pdf_equal(pdf, HERE / "html_font_color_name.pdf", tmp_path)
+
+
+def test_html_multiline_cell(tmp_path):
+    pdf = MyFPDF()
+    pdf.add_page()
+
+    html = """<table border="1"><thead><tr>
+    <th width="30%">First name</th><th width="30%">Last name</th><th width="15%">Age</th><th width="25%">City</th>
+    </tr></thead><tbody>
+    <tr><td>Jean Abdul William the XVII-th</td><td>Smith</td><td>34</td><td>Saint-Mahturin-sur-Loire - it may even be so long that multiple lines are needed to write it down completely</td></tr>
+    <tr><td>Jules Maria Christof Jan Marie Wessel</td><td>van Binsbergen</td><td>7</td><td>Home</td>
+    <tr><td>Short</td><td>y</td><td>7</td><td>None</td>
+    </tr></tbody></table>
+    """
+
+    pdf.write_html(html)
+
+    pdf.output(r'c:\data\test.pdf')
+
+


### PR DESCRIPTION
This is the implementation for #91 
Conflicts with #211 (was not aware of this)

the idea of this implementation is to separate the creation of the table from the HTML parser.
The HTML parser will create a Table object when a `<table>` tag is encountered. Following `<td>`, `<tr>` and `<img>` tags as well as data is then passed to the Table object.
The table is only processed when `</table>` is encountered. At that time all the table contents are known and the cell sizes can be determined. 

Good:
- Table object can also be used outside html

Issues:
- multi_cell does not support text formatting, so formatting of text inside a cell can not be handled.
- mixed image/text cells. 

It would be great if there was a function like multi_cell that could handle HTML. In that case it would be a matter of passing all the html between `<td>` tags to that function.