### PR TITLE
New Line After Header *Before* Font Change

### DIFF
--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -560,9 +560,9 @@ class HTML2FPDF(HTMLParser):
         if tag in self.heading_sizes:
             self.heading_level = None
             face, size, color = self.font_stack.pop()
+            self.pdf.ln(self.h)
             self.set_font(face, size)
             self.set_text_color(*color)
-            self.pdf.ln(self.h)
             self.align = None
         if tag == "pre":
             face, size, color = self.font_stack.pop()


### PR DESCRIPTION
Currently, when exiting the h1/h2/etc tag the process was to first pop to the previous font and _then_ create a new line (`pdf.ln(self.h)`). The problem is that if the head font is large and the previous font was significantly smaller, then the new line is not large enough to escape past the bottom of the head font. I've simple reversed this order and tested it locally - seems to work perfectly now for various header and non-header font sizes.