### PR TITLE
added links to other translations on Hindi and Spanish tutorial pages

### DIFF
--- a/docs/Tutorial-es.md
+++ b/docs/Tutorial-es.md
@@ -1,6 +1,8 @@
 ﻿Los diferentes ejemplos muestran rápidamente como usar fpdf2. Encontrará todas las características principales explicadas.
 
-English: [Tutorial](Tutorial.md)
+English version: [Tutorial](Tutorial.md)
+
+Deutsche Version: [Tutorial-de](Tutorial-de.md)
 
 हिंदी संस्करण: [Tutorial-हिंदी](Tutorial-हिंदी.md)
 

--- a/docs/Tutorial-हिंदी.md
+++ b/docs/Tutorial-हिंदी.md
@@ -1,6 +1,8 @@
 विभिन्न उदाहरण जल्दी से दिखाते हैं कि fpdf2 का उपयोग कैसे करें। आपको सभी मुख्य विशेषताओं की व्याख्या मिल जाएगी।
 
-English: [Tutorial](Tutorial.md)
+English version: [Tutorial](Tutorial.md)
+
+Deutsche Version: [Tutorial-de](Tutorial-de.md)
 
 Versión en español: [Tutorial-es](Tutorial-es.md)
 

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -247,7 +247,7 @@ In the first page of the example, we used
 
 To add an internal link pointing to the second page, we used the
  [add_link()](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.add_link)
- method, whch creates a clickable area which we named "link" that directs to
+ method, which creates a clickable area which we named "link" that directs to
  another place within the document. On the second page, we used
  [set_link()](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.set_link)
  to define the destination area for the link we just created.


### PR DESCRIPTION
I added the german version to both the spanish and hindi page which were missing it. I also added "version" next to "English" since that seemed to be the pattern