### PR TITLE
Fix: display Unicode characters in the table of content (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and [PEP 440](https://www.python.org/dev/peps/pep-0440/).
 
 ### Fixed
 - `will_page_break()` & `accept_page_break` are not invoked anymore during a call to `multi_cell(split_only=True)`
+- display Unicode characters in the table of content
 
 ## [2.4.6] - 2021-11-16
 ### Added

--- a/fpdf/syntax.py
+++ b/fpdf/syntax.py
@@ -198,9 +198,7 @@ def camel_case(property_name):
 
 class PDFString(str):
     def serialize(self):
-        # Filtering out characters that are not encodable as Latin1 for now,
-        # as an outline /Title seemingly cannot "just" be encoded as UTF-16BE:
-        return f'({self.encode("latin-1", "ignore").decode("latin-1")})'
+        return f'({self.encode("UTF-16", "ignore").decode("latin-1")})'
 
 
 class PDFArray(list):


### PR DESCRIPTION
I was able to fix issue #320. Now Hebrew and Russian characters are displayed correctly.