### PR TITLE
Fix: get_string_width() unicode and markdown broken

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -869,7 +869,7 @@ class FPDF(GraphicsStateMixin):
         ):
             font = self.fonts[self.font_family + style]
             if self.unifontsubset:
-                for char in s:
+                for char in txt_frag:
                     w += _char_width(font, ord(char))
             else:
                 w += sum(_char_width(font, char) for char in txt_frag)


### PR DESCRIPTION
Bad repeated render of whole "s" string instead of partial "txt_frag".

Signed-off-by: Martin Cerveny <m.cerveny@computer.org>
