### PR TITLE
Fix: push/restore (q/Q) losts selected font

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -2072,7 +2072,7 @@ class FPDF(GraphicsStateMixin):
                 dx = self.c_margin
 
             if self.fill_color != self.text_color:
-                s += f"q {self.text_color} "
+                s += f"{self.text_color} "
 
             prev_font_style, prev_underline = self.font_style, self.underline
             s_width, underlines = 0, []
@@ -2157,7 +2157,7 @@ class FPDF(GraphicsStateMixin):
                 )
 
             if self.fill_color != self.text_color:
-                s += " Q"
+                s += f" {self.fill_color}"
 
             if link:
                 self.link(


### PR DESCRIPTION
Problem:

- before text is rendered and self.fill_color!=self.text_color whole context is pushed (q)
- when font is changed, font change is generated and remembered (self.font_style)
- after text is rendering whole context (with old font) is restored (Q) but not restored in self.font_style
- next rendering uses different "subset" table for different font

Proposed solution - restore only self.fill_color

Is this sufficient ?
Is the push/restore only for self.fill_color ?

[test.pdf](https://github.com/PyFPDF/fpdf2/files/8191554/test.pdf)
[test_bad.pdf](https://github.com/PyFPDF/fpdf2/files/8191556/test_bad.pdf)

Test code:
```
import fpdf

pdf = fpdf.FPDF(orientation='portrait', unit='mm', format='A4', font_cache_dir='pdf/fonts/')
pdf.add_font('dejavusans', fname='pdf/fonts/DejaVuSans.ttf', uni=True)
pdf.add_font('dejavusans', style="B", fname='pdf/fonts/DejaVuSans-Bold.ttf', uni=True)
pdf.add_font('dejavusans', style="I",  fname='pdf/fonts/DejaVuSans-Oblique.ttf', uni=True)
pdf.add_font('dejavusans', style="BI", fname='pdf/fonts/DejaVuSans-BoldOblique.ttf', uni=True)
pdf.add_page()
pdf.set_font('dejavusans',size=10)
pdf.set_fill_color(255,0,0)
pdf.multi_cell(50, markdown=True,txt="aa bb cc **dd ee dd ee dd ee dd ee dd ee dd ee**")
pdf.output('test.pdf')
```