### PR TITLE
Fixing calls to FPDF.cell in tutorial/tuto*.py demo scripts to match new API since v2.5.2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,4 +4,4 @@ max-line-length=135
 
 [SIMILARITIES]
 # Restricting duplicate-code check:
-min-similarity-lines=10
+min-similarity-lines=30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 - new `FPDF.page_mode` property, allowing to display a PDF in **full screen**: [link to docs](https://pyfpdf.github.io/fpdf2/PageFormatAndOrientation.html#full-screen)
 - new `FPDF.viewer_preferences` property: [link to docs](https://pyfpdf.github.io/fpdf2/PageFormatAndOrientation.html#viewer-preferences)
 ### Fixed
-- removed a debug `print()` statement (`multi_cell: new_x=... new_y=...`) that had been left in [multi_cell()](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.multi_cell) method
+- removed a debug `print()` statement (`multi_cell: new_x=... new_y=...`) that had been left in [multi_cell()](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.multi_cell) method 🤦‍♂️
 ### Modified
 - when [`regular_polygon()`](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.regular_polygon) is called with `style="f"`,
   the shape outline is not drawn anymore. Use `style="DF"` to also draw a line around its perimeter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 - new `FPDF.viewer_preferences` property: [link to docs](https://pyfpdf.github.io/fpdf2/PageFormatAndOrientation.html#viewer-preferences)
 ### Fixed
 - removed a debug `print()` statement (`multi_cell: new_x=... new_y=...`) that had been left in [multi_cell()](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.multi_cell) method 🤦‍♂️
+- preserved backward compatibility with PyFPDF for passing positional arguments to `cell()` & `multi_cell()`, which was broken in 2.5.2
 ### Modified
 - when [`regular_polygon()`](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.regular_polygon) is called with `style="f"`,
   the shape outline is not drawn anymore. Use `style="DF"` to also draw a line around its perimeter.

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -2224,14 +2224,14 @@ class FPDF(GraphicsStateMixin):
         h=None,
         txt="",
         border=0,
-        new_x=XPos.RIGHT,
-        new_y=YPos.TOP,
         ln="DEPRECATED",
         align=Align.L,
         fill=False,
         link="",
         center="DEPRECATED",
         markdown=False,
+        new_x=XPos.RIGHT,
+        new_y=YPos.TOP,
     ):
         """
         Prints a cell (rectangular area) with optional borders, background color and
@@ -2769,12 +2769,12 @@ class FPDF(GraphicsStateMixin):
         fill=False,
         split_only=False,
         link="",
-        new_x=XPos.RIGHT,
-        new_y=YPos.NEXT,
         ln="DEPRECATED",
         max_line_height=None,
         markdown=False,
         print_sh=False,
+        new_x=XPos.RIGHT,
+        new_y=YPos.NEXT,
     ):
         """
         This method allows printing text with line breaks. They can be automatic

--- a/tutorial/form.py
+++ b/tutorial/form.py
@@ -29,7 +29,7 @@ class Form:
         )
         # parse form format file and create fields dict
         self.fields = {}
-        with open(infile) as file:
+        with open(infile, encoding="utf8") as file:
             for linea in file.readlines():
                 kargs = {}
                 for i, v in enumerate(linea.split(";")):
@@ -94,7 +94,7 @@ class Form:
             # m_k = 72 / 2.54
             # h = (size/m_k)
             pdf.set_xy(x1, y1)
-            pdf.cell(w=x2 - x1, h=y2 - y1, txt=text, border=0, ln=0, align=align)
+            pdf.cell(w=x2 - x1, h=y2 - y1, txt=text, align=align)
             # pdf.Text(x=x1,y=y1,txt=text)
 
     @staticmethod

--- a/tutorial/tuto2.py
+++ b/tutorial/tuto2.py
@@ -10,7 +10,7 @@ class PDF(FPDF):
         # Moving cursor to the right:
         self.cell(80)
         # Printing title:
-        self.cell(30, 10, "Title", 1, 0, "C")
+        self.cell(30, 10, "Title", border=1, align="C")
         # Performing a line break:
         self.ln(20)
 
@@ -20,7 +20,7 @@ class PDF(FPDF):
         # Setting font: helvetica italic 8
         self.set_font("helvetica", "I", 8)
         # Printing page number:
-        self.cell(0, 10, f"Page {self.page_no()}/{{nb}}", 0, 0, "C")
+        self.cell(0, 10, f"Page {self.page_no()}/{{nb}}", align="C")
 
 
 # Instantiation of inherited class
@@ -28,5 +28,5 @@ pdf = PDF()
 pdf.add_page()
 pdf.set_font("Times", size=12)
 for i in range(1, 41):
-    pdf.cell(0, 10, f"Printing line number {i}", 0, 1)
-pdf.output("tuto2.pdf")
+    pdf.cell(0, 10, f"Printing line number {i}", new_x="LMARGIN", new_y="NEXT")
+pdf.output("new-tuto2.pdf")

--- a/tutorial/tuto3.py
+++ b/tutorial/tuto3.py
@@ -15,7 +15,16 @@ class PDF(FPDF):
         # Setting thickness of the frame (1 mm)
         self.set_line_width(1)
         # Printing title:
-        self.cell(width, 9, self.title, 1, 1, "C", True)
+        self.cell(
+            width,
+            9,
+            self.title,
+            border=1,
+            new_x="LMARGIN",
+            new_y="NEXT",
+            align="C",
+            fill=True,
+        )
         # Performing a line break:
         self.ln(10)
 
@@ -27,7 +36,7 @@ class PDF(FPDF):
         # Setting text color to gray:
         self.set_text_color(128)
         # Printing page number
-        self.cell(0, 10, f"Page {self.page_no()}", 0, 0, "C")
+        self.cell(0, 10, f"Page {self.page_no()}", align="C")
 
     def chapter_title(self, num, label):
         # Setting font: helvetica 12
@@ -35,7 +44,15 @@ class PDF(FPDF):
         # Setting background color
         self.set_fill_color(200, 220, 255)
         # Printing chapter name:
-        self.cell(0, 6, f"Chapter {num} : {label}", 0, 1, "L", True)
+        self.cell(
+            0,
+            6,
+            f"Chapter {num} : {label}",
+            new_x="LMARGIN",
+            new_y="NEXT",
+            align="L",
+            fill=True,
+        )
         # Performing a line break:
         self.ln(4)
 

--- a/tutorial/tuto4.py
+++ b/tutorial/tuto4.py
@@ -15,7 +15,16 @@ class PDF(FPDF):
         self.set_fill_color(230, 230, 0)
         self.set_text_color(220, 50, 50)
         self.set_line_width(1)
-        self.cell(width, 9, self.title, 1, 1, "C", True)
+        self.cell(
+            width,
+            9,
+            self.title,
+            border=1,
+            new_x="LMARGIN",
+            new_y="NEXT",
+            align="C",
+            fill=True,
+        )
         self.ln(10)
         # Saving ordinate position:
         self.y0 = self.get_y()
@@ -24,7 +33,7 @@ class PDF(FPDF):
         self.set_y(-15)
         self.set_font("helvetica", "I", 8)
         self.set_text_color(128)
-        self.cell(0, 10, f"Page {self.page_no()}", 0, 0, "C")
+        self.cell(0, 10, f"Page {self.page_no()}", align="C")
 
     def set_col(self, col):
         # Set column position:
@@ -50,7 +59,15 @@ class PDF(FPDF):
     def chapter_title(self, num, label):
         self.set_font("helvetica", "", 12)
         self.set_fill_color(200, 220, 255)
-        self.cell(0, 6, f"Chapter {num} : {label}", 0, 1, "L", True)
+        self.cell(
+            0,
+            6,
+            f"Chapter {num} : {label}",
+            new_x="LMARGIN",
+            new_y="NEXT",
+            border="L",
+            fill=True,
+        )
         self.ln(4)
         # Saving ordinate position:
         self.y0 = self.get_y()

--- a/tutorial/tuto5.py
+++ b/tutorial/tuto5.py
@@ -14,16 +14,16 @@ class PDF(FPDF):
 
     def improved_table(self, headings, rows, col_widths=(42, 39, 35, 40)):
         for col_width, heading in zip(col_widths, headings):
-            self.cell(col_width, 7, heading, 1, 0, "C")
+            self.cell(col_width, 7, heading, border=1, align="C")
         self.ln()
         for row in rows:
-            self.cell(col_widths[0], 6, row[0], "LR")
-            self.cell(col_widths[1], 6, row[1], "LR")
-            self.cell(col_widths[2], 6, row[2], "LR", 0, "R")
-            self.cell(col_widths[3], 6, row[3], "LR", 0, "R")
+            self.cell(col_widths[0], 6, row[0], border="LR")
+            self.cell(col_widths[1], 6, row[1], border="LR")
+            self.cell(col_widths[2], 6, row[2], border="LR", align="R")
+            self.cell(col_widths[3], 6, row[3], border="LR", align="R")
             self.ln()
         # Closure line:
-        self.cell(sum(col_widths), 0, "", "T")
+        self.cell(sum(col_widths), 0, "", border="T")
 
     def colored_table(self, headings, rows, col_widths=(42, 39, 35, 42)):
         # Colors, line width and bold font:
@@ -33,7 +33,7 @@ class PDF(FPDF):
         self.set_line_width(0.3)
         self.set_font(style="B")
         for col_width, heading in zip(col_widths, headings):
-            self.cell(col_width, 7, heading, 1, 0, "C", True)
+            self.cell(col_width, 7, heading, border=1, align="C", fill=True)
         self.ln()
         # Color and font restoration:
         self.set_fill_color(224, 235, 255)
@@ -41,10 +41,10 @@ class PDF(FPDF):
         self.set_font()
         fill = False
         for row in rows:
-            self.cell(col_widths[0], 6, row[0], "LR", 0, "L", fill)
-            self.cell(col_widths[1], 6, row[1], "LR", 0, "L", fill)
-            self.cell(col_widths[2], 6, row[2], "LR", 0, "R", fill)
-            self.cell(col_widths[3], 6, row[3], "LR", 0, "R", fill)
+            self.cell(col_widths[0], 6, row[0], border="LR", align="L", fill=fill)
+            self.cell(col_widths[1], 6, row[1], border="LR", align="L", fill=fill)
+            self.cell(col_widths[2], 6, row[2], border="LR", align="R", fill=fill)
+            self.cell(col_widths[3], 6, row[3], border="LR", align="R", fill=fill)
             self.ln()
             fill = not fill
         self.cell(sum(col_widths), 0, "", "T")


### PR DESCRIPTION
and also preserving backward compatibility with PyFPDF for passing positional arguments to `cell()` & `multi_cell()`, which was broken in 2.5.2 - fix #413