### PR TITLE
Fixing support for "x" & "y" attributes in SVG <use> tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 - allowing to change appearance of [highlight annotations](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.highlight) by specifying a [`TextMarkupType`](https://pyfpdf.github.io/fpdf2/fpdf/enums.html#fpdf.enums.TextMarkupType)
 - documentation on how to control objects transparency: [link to docs](https://pyfpdf.github.io/fpdf2/Transparency.html)
 - documentation on how to create tables and charts using [pandas](https://pandas.pydata.org/) DataFrames: [link to docs](https://pyfpdf.github.io/fpdf2/Maths.html), thanks to @iwayankurniawan
+### Fixed
+- support for `"x"` & `"y"` attributes in SVG `<use>` tags
 
 ## [2.5.4] - 2022-05-05
 ### Added

--- a/fpdf/drawing.py
+++ b/fpdf/drawing.py
@@ -3983,6 +3983,9 @@ class GraphicsContext:
             merged_style = style.__class__.merge(style, self.style)
 
             if debug_stream is not None:
+                if self._transform:
+                    debug_stream.write(f"({self._transform})")
+
                 styles_dbg = []
                 for attr in merged_style.MERGE_PROPERTIES:
                     val = getattr(merged_style, attr)

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -1020,8 +1020,8 @@ class SVGObject:
             if child.tag in xmlns_lookup("svg", "path"):
                 self.build_path(child)
 
-    # this assumes xrefs only reference already-defined ids. I don't know if this is
-    # required by the SVG spec.
+    # this assumes xrefs only reference already-defined ids.
+    # I don't know if this is required by the SVG spec.
     @force_nodocument
     def build_xref(self, xref):
         """Resolve a cross-reference to an already-seen SVG element by ID."""
@@ -1043,6 +1043,13 @@ class SVGObject:
             raise ValueError(
                 f"use {xref} references nonexistent ref id {ref}"
             ) from None
+
+        if "x" in xref.attrib or "y" in xref.attrib:
+            # Quoting the SVG spec - 5.6.2. Layout of re-used graphics:
+            # > The x and y properties define an additional transformation translate(x,y)
+            x, y = float(xref.attrib.get("x", 0)), float(xref.attrib.get("y", 0))
+            pdf_group.transform = drawing.Transform.translation(x=x, y=y)
+        # Note that we currently do not support "width" & "height" in <use>
 
         return pdf_group
 

--- a/test/svg/generated_pdf/use-xlink-href.pdf
+++ b/test/svg/generated_pdf/use-xlink-href.pdf
@@ -1,0 +1,82 @@
+%PDF-1.4
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/Group <</Type /Group /S /Transparency /CS /DeviceRGB>>
+/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Filter /FlateDecode /Length 195>>
+stream
+xœÝ‘=!…û=Å»À" x‚MìtKc…‰6¯ï,ÄXØ»™„ùáÍ_ ­|ÀkX` ÙFqÆEM< eì¦™pârå‹hEÑú"^ÃQâ*Õ"]Šqf$ãÖÚ/wžÊ€Ò¼N÷ˆ‚ÚG0Þ+¢è9¨÷âœS!˜ZýPWIbHÙèc®Ý¥¹ÏäL–5m{BÂ3NÅ³1ú6?oLØêWËI«•DÞQ7j‚¶¢¯{ò¿“³opKÃå
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R]
+/Count 1
+/MediaBox [0 0 340.16 148.82]
+>>
+endobj
+5 0 obj
+<< /Type /ExtGState
+/LC 0 >>
+endobj
+6 0 obj
+<< /Type /ExtGState
+/LW 2 >>
+endobj
+7 0 obj
+<< /Type /ExtGState
+/LW 0.567
+/D [[] 0] >>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+>>
+/XObject <<
+>>
+/ExtGState <<
+/GS0 5 0 R
+/GS1 6 0 R
+/GS2 7 0 R
+>>
+>>
+endobj
+8 0 obj
+<<
+/CreationDate (D:19691231190000)
+>>
+endobj
+9 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000408 00000 n 
+0000000640 00000 n 
+0000000009 00000 n 
+0000000143 00000 n 
+0000000494 00000 n 
+0000000538 00000 n 
+0000000582 00000 n 
+0000000784 00000 n 
+0000000838 00000 n 
+trailer
+<<
+/Size 10
+/Root 9 0 R
+/Info 8 0 R
+>>
+startxref
+941
+%%EOF

--- a/test/svg/parameters.py
+++ b/test/svg/parameters.py
@@ -760,6 +760,7 @@ test_svg_sources = (
     pytest.param(svgfile("issue_358.svg"), id="arc start & initial point"),  # issue 358
     pytest.param(svgfile("Ghostscript_colorcircle.svg"), id="ghostscript colorcircle"),
     pytest.param(svgfile("Ghostscript_escher.svg"), id="ghostscript escher"),
+    pytest.param(svgfile("use-xlink-href.svg"), id="use xlink:href - issue #446"),
 )
 
 svg_path_edge_cases = (

--- a/test/svg/svg_sources/use-xlink-href.svg
+++ b/test/svg/svg_sources/use-xlink-href.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" standalone="no"?>
+<svg width="12cm" height="5.25cm" viewBox="0 0 1200 525" version="1.1"
+     xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Tests usages of xlink:href - issue #446</title>
+  <defs>
+    <g id="ellipseBase">
+      <ellipse cx="100" cy="100" rx="100" ry="50"
+               fill="none" stroke="#888888" stroke-width="2" />
+    </g>
+    <g id="ellipseTranslated">
+      <ellipse cx="100" cy="100" rx="100" ry="50"
+               fill="none" stroke="#888888" stroke-width="2"
+               transform="translate(50 50)"/>
+    </g>
+  </defs>
+  <use xlink:href="#ellipseBase"/>
+  <g transform="translate(0 100)scale(0.5 0.5)">
+    <use xlink:href="#ellipseBase"/>
+  </g>
+  <g transform="translate(0 200)">
+    <use x="100" xlink:href="#ellipseBase"/>
+  </g>
+  <g transform="translate(0 300)">
+    <use x="100" xlink:href="#ellipseTranslated"/>
+  </g>
+</svg>
+


### PR DESCRIPTION
Spotted in #446