### PR TITLE
Fix docs building

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ or [open a discussion](https://github.com/PyFPDF/fpdf2/discussions).
 ### Related ###
 
 * Looking for alternative libraries? Check out [this detailed list of PDF-related Python libs by Patrick Maupin (`pdfrw` author)](https://github.com/pmaupin/pdfrw#other-libraries).
-  There is also [borb](https://github.com/jorisschellekens/borb), [pikepdf](https://github.com/pikepdf/pikepdf) & [WeasyPrint](https://github.com/Kozea/WeasyPrint).
+  There is also [borb](https://github.com/jorisschellekens/borb), [pikepdf](https://github.com/pikepdf/pikepdf), [WeasyPrint](https://github.com/Kozea/WeasyPrint) & [pydyf](https://pypi.org/project/pydyf/).
   We have some documentations about combining `fpdf2` with [`borb`](borb.md) & [`pdfrw`](ExistingPDFs.md).
 * [Create PDFs with Python](https://www.youtube.com/playlist?list=PLjNQtX45f0dR9K2sMJ5ad9wVjqslNBIC0) : a series of tutorial videos by bvalgard
 * [digidigital/Extensions-and-Scripts-for-pyFPDF-fpdf2](https://github.com/digidigital/Extensions-and-Scripts-for-pyFPDF-fpdf2) : scripts ported from PHP to add transpareny to elements of the page or part of an image, allow to write circular text,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,7 @@ mkdocs-material
 mkdocs-include-markdown-plugin
 mkdocs-with-pdf
 pdoc3
+# We lock weasyprint version to avoid the following error:
+# TypeError: 'float' object is not iterable
+# https://github.com/PyFPDF/fpdf2/runs/7263726951
+weasyprint==55.0


### PR DESCRIPTION
https://github.com/PyFPDF/fpdf2/runs/7263726951?check_suite_focus=true
```
INFO     -  Output a PDF to "/home/runner/work/fpdf2/fpdf2/public/fpdf2-manual.pdf".
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.5/x64/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/mkdocs/__main__.py", line 192, in build_command
    build.build(config.load_config(**kwargs), dirty=not clean)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/mkdocs/commands/build.py", line 317, in build
    config['plugins'].run_event('post_build', config=config)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/mkdocs/plugins.py", line 104, in run_event
    result = method(**kwargs)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/mkdocs_with_pdf/plugin.py", line 135, in on_post_build
    self.generator.on_post_build(config, self.config['output_path'])
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/mkdocs_with_pdf/generator.py", line 157, in on_post_build
    render.write_pdf(abs_pdf_path)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/document.py", line 335, in write_pdf
    pdf = generate_pdf(
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/pdf/__init__.py", line 316, in generate_pdf
    page.paint(stream, scale=scale)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/document.py", line 96, in paint
    draw_page(self._page_box, stream)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/draw.py", line 68, in draw_page
    draw_stacking_context(stream, stacking_context)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/draw.py", line 169, in draw_stacking_context
    draw_stacking_context(stream, child_context)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/draw.py", line 169, in draw_stacking_context
    draw_stacking_context(stream, child_context)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/draw.py", line 164, in draw_stacking_context
    draw_inline_level(
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/draw.py", line 956, in draw_inline_level
    draw_inline_level(
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/draw.py", line 956, in draw_inline_level
    draw_inline_level(
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/draw.py", line 960, in draw_inline_level
    draw_replacedbox(stream, box)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/draw.py", line 923, in draw_replacedbox
    box.replacement.draw(
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/images.py", line 86, in draw
    self._svg.draw(
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/svg/__init__.py", line 359, in draw
    self.draw_node(self.tree, size('12pt'))
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/svg/__init__.py", line 426, in draw_node
    self.draw_node(child, font_size, fill_stroke)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/svg/__init__.py", line 426, in draw_node
    self.draw_node(child, font_size, fill_stroke)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/svg/__init__.py", line 435, in draw_node
    self.fill_stroke(node, font_size)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/svg/__init__.py", line 605, in fill_stroke
    fill_drawn = draw_gradient_or_pattern(
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/svg/defs.py", line 72, in draw_gradient_or_pattern
    return draw_gradient(
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/svg/defs.py", line 241, in draw_gradient
    function = group.create_stitching_function(
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/pdf/stream.py", line 466, in create_stitching_function
    'Functions': pydyf.Array(sub_functions),
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/pydyf/__init__.py", line 399, in __init__
    list.__init__(self, array or [])
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/svg/defs.py", line 239, in <genexpr>
    group.create_interpolation_function((0, 1), c0, c1, 1)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/weasyprint/pdf/stream.py", line 454, in create_interpolation_function
    'C0': pydyf.Array(c0),
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/pydyf/__init__.py", line 399, in __init__
    list.__init__(self, array or [])
TypeError: 'float' object is not iterable
```
I wasn't able to reproduce this error on my local environment, with the same libs versions.