### PR TITLE
typo in docs for pdfrw fork link fixed

### DIFF
--- a/docs/ExistingPDFs.md
+++ b/docs/ExistingPDFs.md
@@ -65,4 +65,4 @@ writer.write(OUT_FILEPATH)
 This example relies on [pdfrw _Pull Request_ #216](https://github.com/pmaupin/pdfrw/pull/216).
 Until it is merged, you can install a forked version of `pdfrw` including the required patch:
 
-    pip install git+https://github.com/PyPDF/pdfrw.git@addpage_at_index
+    pip install git+https://github.com/PyFPDF/pdfrw.git@addpage_at_index


### PR DESCRIPTION
This just fixes a tiny typo in the docs that made the link to install the pdfrw fork invalid

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [ ] The GitHub pipeline is OK (green), <!-- The maintainers will trigger it if this is your 1st contribution -->
      meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [x] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

<!-- Feel free to add additional comments, and to ask questions if some of those guidelines are unclear to you! -->

<!--
Once a PR is merged, maintainers will add your name to the contributors table in README.md.
If they forget, or you do not wish this to happen, please mention it.
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/PyFPDF/fpdf2/blob/master/LICENSE).
