### PR TITLE
SVG stroke-width with explicit unit, fixes #526

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 - `fpdf2` now uses [fontTools](https://fonttools.readthedocs.io/en/latest/) to read and embed fonts in the PDF, thanks to @gmischler and @RedShy
 
 ### Fixed
+- The SVG parser now accepts stroke-width attribute values with an explicit unit, thanks to @gmischler; [#526](https://github.com/PyFPDF/fpdf2/issues/526)
 - Text following a HTML heading can't overlap with that heading anymore, thanks to @gmischler
 - `arc()` not longer renders artefacts at intersection point, thanks to @Jmillan-Dev; [#488](https://github.com/PyFPDF/fpdf2/issues/488)
 - [`write_html()`](https://pyfpdf.github.io/fpdf2/HTML.html):

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -119,7 +119,10 @@ angle_units = {
 @force_nodocument
 def resolve_length(length_str, default_unit="pt"):
     """Convert a length unit to our canonical length unit, pt."""
-    value, unit = unit_splitter.match(length_str).groups()
+    match = unit_splitter.match(length_str)
+    if match == None:
+        raise ValueError(f"Unable to parse '{length_str}' as a length") from None
+    value, unit = match.groups()
     if not unit:
         unit = default_unit
 
@@ -193,7 +196,7 @@ def svgcolor(colorstr):
 
 @force_nodocument
 def convert_stroke_width(incoming):
-    val = float(incoming)
+    val = resolve_length(incoming)
     if val < 0:
         raise ValueError(f"stroke width {incoming} cannot be negative")
     if val == 0:

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -120,7 +120,7 @@ angle_units = {
 def resolve_length(length_str, default_unit="pt"):
     """Convert a length unit to our canonical length unit, pt."""
     match = unit_splitter.match(length_str)
-    if match == None:
+    if match is None:
         raise ValueError(f"Unable to parse '{length_str}' as a length") from None
     value, unit = match.groups()
     if not unit:

--- a/test/svg/parameters.py
+++ b/test/svg/parameters.py
@@ -580,6 +580,12 @@ test_svg_attribute_conversion = (
         no_error(),
         id="stroke-width number",
     ),
+    pytest.param(  # issue #526
+        '<path stroke-width="2px"/>',
+        Gs(stroke_width=2 * 0.75),
+        no_error(),
+        id="stroke-width number",
+    ),
     pytest.param(
         '<path stroke-width="inherit"/>',
         Gs(),


### PR DESCRIPTION
e.g. Fixes #526

**Checklist**:
- [x] The GitHub pipeline is OK (green), <!-- The maintainers will trigger it if this is your 1st contribution -->
      meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.
- [x] A unit test is covering the code added / modified by this PR
- [x] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->
- [NA] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder
- [x] A mention of the change is present in `CHANGELOG.md`


By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/PyFPDF/fpdf2/blob/master/LICENSE).
