### PR TITLE
Forbid use of `get_y()` & `local_context()` inside `unbreakable()` as it is currently not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ### Fixed
 - automatic page break is never performed on an empty page (when the Y position is at the top margin)
 - fixed [`insert_toc_placeholder()`](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.insert_toc_placeholder) usage with [`footer()`](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.footer) and `{{nb}}`; [#548](https://github.com/PyFPDF/fpdf2/issues/548)
-- the SVG parser now accepts stroke-width attribute values with an explicit unit, thanks to @gmischler; [#526](https://github.com/PyFPDF/fpdf2/issues/526)
+- the SVG parser now accepts `stroke-width` attribute values with an explicit unit, thanks to @gmischler; [#526](https://github.com/PyFPDF/fpdf2/issues/526)
 - the SVG parser now accepts absolute units for `width` and `height` attributes, thanks to @darioackermann; [#555](https://github.com/PyFPDF/fpdf2/issues/555)
+### Changed
+- forbid use of `get_y()` & `local_context()` inside `unbreakable()` as it is currently not supported; [#557](https://github.com/PyFPDF/fpdf2/discussions/557)
 
 ## [2.5.7] - 2022-09-08
 ### Changed

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -509,6 +509,10 @@ class FPDF(GraphicsStateMixin):
         # page number -> array of 8 × n numbers:
         self.text_quad_points = defaultdict(list)
 
+        self._is_unbreakable = (
+            False  # indicates that we are inside an .unbreakable() code block
+        )
+
     def write_html(self, text, *args, **kwargs):
         """Parse HTML and convert it to PDF"""
         kwargs2 = vars(self)
@@ -2580,6 +2584,10 @@ class FPDF(GraphicsStateMixin):
         Args:
             **kwargs: key-values settings to set at the beggining of this context.
         """
+        if self._is_unbreakable:
+            raise FPDFException(
+                "cannot create a local context inside an unbreakable() code block"
+            )
         self._push_local_stack()
         gs = None
         for key, value in kwargs.items():
@@ -3798,6 +3806,10 @@ class FPDF(GraphicsStateMixin):
 
     def get_y(self):
         """Returns the ordinate of the current position."""
+        if self._is_unbreakable:
+            raise FPDFException(
+                "Using get_y() inside an unbreakable() code block is error-prone"
+            )
         return self.y
 
     def set_y(self, y):
@@ -5048,6 +5060,7 @@ class FPDF(GraphicsStateMixin):
         prev_page, prev_y = self.page, self.y
         recorder = FPDFRecorder(self, accept_page_break=False)
         recorder.page_break_triggered = False
+        self._is_unbreakable = True
         LOGGER.debug("Starting unbreakable block")
         yield recorder
         y_scroll = recorder.y - prev_y + (recorder.page - prev_page) * self.eph
@@ -5059,6 +5072,7 @@ class FPDF(GraphicsStateMixin):
             recorder.pdf._perform_page_break()
             recorder.replay()
             recorder.page_break_triggered = True
+        self._is_unbreakable = False
         LOGGER.debug("Ending unbreakable block")
 
     @contextmanager

--- a/test/text/test_unbreakable.py
+++ b/test/text/test_unbreakable.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import fpdf
 from test.conftest import assert_pdf_equal
 
+import pytest
+
 
 HERE = Path(__file__).resolve().parent
 
@@ -215,3 +217,29 @@ def test_multi_cell_table_unbreakable_with_split_only(tmp_path):  # issue 359
     assert_pdf_equal(
         pdf, HERE / "multi_cell_table_unbreakable_with_split_only.pdf", tmp_path
     )
+
+
+def test_unbreakable_with_local_context():  # discussion 557
+    pdf = fpdf.FPDF()
+    pdf.set_font("Helvetica", "", 10)
+    pdf.add_page()
+    pdf.set_y(270)  # Set position so that adding a cell triggers a page break
+    with pytest.raises(fpdf.FPDFException):
+        with pdf.unbreakable() as doc:
+            with doc.local_context(fill_opacity=0.3):
+                doc.cell(doc.epw, 10, "Cell text content", border=1, fill=True)
+    pdf.set_y(270)  # Set position so that adding a cell triggers a page break
+    with pytest.raises(fpdf.FPDFException):
+        with pdf.unbreakable() as doc:
+            with doc.local_context(text_color=(255, 0, 0)):
+                doc.cell(doc.epw, 10, "Cell text content", border=1)
+
+
+def test_unbreakable_with_get_y():  # discussion 557
+    pdf = fpdf.FPDF()
+    pdf.set_font("Helvetica", "", 10)
+    pdf.add_page()
+    pdf.set_y(270)  # Set position so that adding a cell triggers a page break
+    with pytest.raises(fpdf.FPDFException):
+        with pdf.unbreakable() as doc:
+            doc.cell(doc.epw, 10, f"doc.get_y(): {doc.get_y()}", border=1)


### PR DESCRIPTION
_cf._ https://github.com/PyFPDF/fpdf2/discussions/557