### PR TITLE
Removing `open()` & `close()` methods, that were only used internally…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ in order to get warned about deprecated features used in your code.
 
 This can also be enabled programmatically with `warnings.simplefilter('default', DeprecationWarning)`.
 
-## [2.5.8] - not released yet
+## [2.6.0] - not released yet
 ### Added
 - demonstration Jupyter notebook: [tutorial/notebook.ipynb](https://github.com/PyFPDF/fpdf2/blob/master/tutorial/notebook.ipynb)
 - support for description list (`<dl>`), description titles (`<dt>`), and description details (`<dd>`) in `write_html()` - thanks to @yk-jp
 - support for monochromatic images (PIL `image.mode == '1'`) thanks to @GerardoAllende
 - [fontTools](https://fonttools.readthedocs.io/en/latest/) minimal version requirement set to 4.34.0; [#524](https://github.com/PyFPDF/fpdf2/issues/524)
+### Removed
+- `open()` & `close()` methods, that were only used internally and should never have been called by end-user code
 ### Deprecated
 - `HTMLMixin` is deprecated, and not needed anymore: the `write_html()` method is now natively available in the `FPDF` class - thanks to @yk-jp
 ### Fixed

--- a/fpdf/enums.py
+++ b/fpdf/enums.py
@@ -4,11 +4,10 @@ from sys import intern
 from .syntax import Name
 
 
-class DocumentState(IntEnum):
-    UNINITIALIZED = 0
-    READY = 1  # page not started yet
-    GENERATING_PAGE = 2
-    CLOSED = 3  # EOF printed
+class DocumentState(IntEnum):  # internal/private enum
+    GENERATING = 0  # default state while building the PDF document
+    CLOSING = 1  # while calling .output() and converting the internal .pages dict to a .buffer
+    CLOSED = 2  # = .output() has been called once and has finished
 
 
 class SignatureFlag(IntEnum):

--- a/test/errors/test_FPDF_errors.py
+++ b/test/errors/test_FPDF_errors.py
@@ -122,7 +122,7 @@ def test_incorrent_number_of_pages_toc():
     pdf.add_page()
     pdf.insert_toc_placeholder(lambda a, b: None, 10)
     with pytest.raises(FPDFException):
-        pdf.close()
+        pdf.output()
 
 
 def test_invalid_page_background():

--- a/test/test_graphics_context.py
+++ b/test/test_graphics_context.py
@@ -147,6 +147,7 @@ def test_change_settings():
 
     # dash_pattern
     pdf = FPDF()
+    pdf.add_page()
     # verify default
     tgt_dash_pattern = dict(dash=0, gap=0, phase=0)
     assert pdf.dash_pattern == tgt_dash_pattern, (


### PR DESCRIPTION
… and should never have been called by end-user code