### PR TITLE
Make sure 'lift' is reset if Fragment changes lift in _render_styled_text_line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 - [`FPDF.image()`](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.image): allowing images path starting with `data` to be passed as input
 - text overflow is better handled by `FPDF.write()` & `FPDF.write_html()` - _cf._ [issue #847](https://github.com/PyFPDF/fpdf2/issues/847)
 - the initial text color is preserved when using `FPDF.write_html()` - _cf._ [issue #846](https://github.com/PyFPDF/fpdf2/issues/846)
+- handle superscript and subscript correctly when rendering `TextLine`- [Pull Request #862](https://github.com/PyFPDF/fpdf2/pull/862) 
 ### Deprecated
 - the `center` optional parameter of [`FPDF.cell()`](https://pyfpdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.cell) is **no more** deprecated, as it allows for horizontal positioning, which is different from text alignment control with `align="C"`
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -2845,6 +2845,7 @@ class FPDF(GraphicsStateMixin):
         s_width, underlines = 0, []
         # We try to avoid modifying global settings for temporary changes.
         current_ws = frag_ws = 0.0
+        current_lift = 0.0
         current_char_vpos = CharVPos.LINE
         current_font = self.current_font
         current_text_mode = self.text_mode
@@ -2894,9 +2895,10 @@ class FPDF(GraphicsStateMixin):
                     current_font = frag.font
                     sl.append(f"/F{frag.font.i} {frag.font_size_pt:.2f} Tf")
                 lift = frag.lift
-                if lift != 0.0:
+                if lift != current_lift:
                     # Use text rise operator:
                     sl.append(f"{lift:.2f} Ts")
+                    current_lift = lift
                 if (
                     frag.text_mode != TextMode.FILL
                     or frag.text_mode != current_text_mode
@@ -2983,6 +2985,7 @@ class FPDF(GraphicsStateMixin):
             # pylint: disable=too-many-boolean-expressions
             if (
                 current_ws != 0.0
+                or current_lift != 0.0
                 or current_char_vpos != CharVPos.LINE
                 or current_font != self.current_font
                 or current_text_mode != self.text_mode

--- a/test/text/test_varied_fragments.py
+++ b/test/text/test_varied_fragments.py
@@ -192,3 +192,35 @@ def test_varfrags_text_mode(tmp_path):
     pdf.ln()
     pdf.write_fragments(frags, align=Align.C)
     assert_pdf_equal(pdf, HERE / "varfrags_text_mode.pdf", tmp_path)
+
+
+def test_varfrags_char_vpos(tmp_path):
+    pdf = FxFPDF()
+    pdf.add_page()
+    pdf.line(pdf.l_margin, pdf.t_margin, pdf.l_margin, pdf.h - pdf.b_margin)
+    pdf.line(
+        pdf.l_margin + pdf.epw,
+        pdf.t_margin,
+        pdf.l_margin + pdf.epw,
+        pdf.h - pdf.b_margin,
+    )
+    pdf.set_font("helvetica", "", 14)
+    f1 = Fragment(TEXT_1, pdf._get_current_graphics_state(), pdf.k)
+    pdf.char_vpos = "SUB"
+    f2 = Fragment(TEXT_2, pdf._get_current_graphics_state(), pdf.k)
+    f3 = Fragment(TEXT_3, f1.graphics_state, pdf.k)
+    pdf.char_vpos = "SUP"
+    f4 = Fragment(TEXT_4, pdf._get_current_graphics_state(), pdf.k)
+    f5 = Fragment(TEXT_5, f1.graphics_state, pdf.k)
+    frags = [f1, f2, f3, f4, f5]
+    pdf.write_fragments(frags)
+    pdf.ln()
+    pdf.ln()
+    pdf.write_fragments(frags, align=Align.J)
+    pdf.ln()
+    pdf.ln()
+    pdf.write_fragments(frags, align=Align.R)
+    pdf.ln()
+    pdf.ln()
+    pdf.write_fragments(frags, align=Align.C)
+    assert_pdf_equal(pdf, HERE / "varfrags_char_vpos.pdf", tmp_path)

--- a/test/text/varfrags_char_vpos.pdf
+++ b/test/text/varfrags_char_vpos.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+1 0 obj
+<<
+/Count 1
+/Kids [3 0 R]
+/MediaBox [0 0 595.28 841.89]
+/Type /Pages
+>>
+endobj
+2 0 obj
+<<
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/Contents 4 0 R
+/Parent 1 0 R
+/Resources 6 0 R
+/Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Filter /FlateDecode
+/Length 388
+>>
+stream
+xœÕ“ÍnÔ0…÷ógÙ.0qìÜx¶Hí±A„ˆ’‹0ŠãÔ?mO˜Ì*±)²Š¯í|>ÇÇ·ÆÇC%šO‡ÚÕÀH%‡_eC‚˜ğåĞ‰£º®Ÿëë†ŞßKH-ª
+İ7Üu§)%…40U-”F7âæ“ì`—˜¾&Ì>¦GØß¢û±BÂ¬ŒwµeqƒÀKàï<lB?[wùwôS"òˆœp÷<ğ’8‡m>§÷"®Z¿'nÌszqúKÕ­1›êÁÏ‘‡Ä©`»ÅpŞFê°szå¤t>Ÿ96õÉúıd²]ğÈSq•§©wƒÇÈÍù©,ıÅÁkÙ­Şds¿ŞÊ£ŸòRNdŞ9?zôØæX*Øy°£óYva=àJÓt¦I¡I¡{ÚA†øü›µ½¾òÔM»Zøÿ-®¤yk¤…Õ(!èXí«05¨¥}õb­Kr-ˆêœ.wO ¥÷•\sZ§ºÚWrRÑ©ç¨¢·&÷í<?
+endstream
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Font <</F1 5 0 R>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+endobj
+7 0 obj
+<<
+/CreationDate (D:19691231190000Z19'00')
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000009 00000 n 
+0000000096 00000 n 
+0000000199 00000 n 
+0000000279 00000 n 
+0000000739 00000 n 
+0000000836 00000 n 
+0000000923 00000 n 
+trailer
+<<
+/Size 8
+/Root 2 0 R
+/Info 7 0 R
+/ID [<CC0E0786A30A7C321C5A18BAF11D1E24><CC0E0786A30A7C321C5A18BAF11D1E24>]
+>>
+startxref
+984
+%%EOF


### PR DESCRIPTION
TextLines with Framents with alternating lift is not rendered correctly as lift operator is not reset. This is fixed here. 

**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [x] The GitHub pipeline is OK (green), <!-- The maintainers will trigger it if this is your 1st contribution -->
      meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [x] A unit test is covering the code added / modified by this PR

- [x] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder "N/A"

- [ ] A mention of the change is present in `CHANGELOG.md`
